### PR TITLE
Install Bitswan Automation Server CLI in Dockerfile and set BITSWAN_CADDY_HOST environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN set -e; \
   LATEST_VERSION="$(curl -sL https://api.github.com/repos/bitswan-space/bitswan-automation-server/releases/latest | jq -r .tag_name)"; \
   TMP_DIR="$(mktemp -d)"; \
   curl -L "https://github.com/bitswan-space/bitswan-automation-server/releases/download/${LATEST_VERSION}/bitswan-automation-server-${LATEST_VERSION}-linux-amd64.tar.gz" | tar -xz -C "$TMP_DIR"; \
-  BIN_PATH="$(find "$TMP_DIR" -type f -perm -u+x -name 'bitswan-automation-server*' | head -n1)"; \
-  if [ -z "$BIN_PATH" ]; then echo "Could not locate bitswan-automation-server binary after extraction" >&2; exit 1; fi; \
-  install -m 0755 "$BIN_PATH" /usr/local/bin/bitswan-automation-server; \
+  BIN_PATH="$(find "$TMP_DIR" -type f -perm -u+x -name 'bitswan*' | head -n1)"; \
+  if [ -z "$BIN_PATH" ]; then echo "Could not locate bitswan binary after extraction" >&2; exit 1; fi; \
+  install -m 0755 "$BIN_PATH" /usr/local/bin/bitswan; \
   rm -rf "$TMP_DIR"
 
 ENV BITSWAN_CADDY_HOST=http://caddy:2019


### PR DESCRIPTION
This pull request updates the `Dockerfile` to add support for the Bitswan Automation Server CLI. The main changes involve installing the CLI and its dependencies, ensuring the binary is available in the container, and setting a related environment variable.

**Bitswan Automation Server CLI installation:**

* Adds installation steps for `curl`, `jq`, and `tar`, which are required to fetch and extract the latest Bitswan Automation Server CLI release.
* Downloads the latest release of the Bitswan Automation Server CLI from GitHub, extracts the binary, and installs it to `/usr/local/bin`.
* Sets the `BITSWAN_CADDY_HOST` environment variable to configure the CLI's connection to the Caddy service.