### PR TITLE
Add sync and sync-continue endpoints for worktree rebase management

### DIFF
--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -721,9 +721,11 @@ async def _complete_merge(
 ) -> dict:
     """After a successful rebase, fast-forward the default branch and pop stash."""
     # Get default branch
-    stdout, _, _ = await call_git_command_with_output(
+    stdout, stderr, rc = await call_git_command_with_output(
         "git", "rev-parse", "--abbrev-ref", "HEAD", cwd=workspace_dir
     )
+    if rc != 0:
+        return {"status": "error", "detail": f"Failed to detect default branch: {stderr.strip()}"}
     default_branch = stdout.strip()
 
     # Get worktree tip

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -800,12 +800,26 @@ async def rebase_and_merge(
         )
 
         if rc != 0:
-            # Rebase hit conflicts — DON'T abort, let the agent resolve them
-            # Get the list of conflicted files
+            # Check whether this is actually a conflict or some other failure
             conflict_stdout, _, _ = await call_git_command_with_output(
                 "git", "diff", "--name-only", "--diff-filter=U", cwd=worktree_path
             )
             conflicted_files = [f for f in conflict_stdout.strip().splitlines() if f]
+
+            if not conflicted_files:
+                # Not a conflict — abort the rebase and restore stash
+                await call_git_command_with_output(
+                    "git", "rebase", "--abort", cwd=worktree_path
+                )
+                if stash_created:
+                    await call_git_command_with_output(
+                        "git", "stash", "pop", cwd=workspace_dir
+                    )
+                rebase_output = f"{stdout.strip()}\n{stderr.strip()}".strip()
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Rebase failed: {rebase_output}",
+                )
 
             return {
                 "status": "conflicts",
@@ -921,6 +935,17 @@ async def sync_worktree(
                 "git", "diff", "--name-only", "--diff-filter=U", cwd=worktree_path
             )
             conflicted_files = [f for f in conflict_stdout.strip().splitlines() if f]
+
+            if not conflicted_files:
+                # Not a conflict — abort the rebase
+                await call_git_command_with_output(
+                    "git", "rebase", "--abort", cwd=worktree_path
+                )
+                rebase_output = f"{stdout.strip()}\n{stderr.strip()}".strip()
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Rebase failed: {rebase_output}",
+                )
 
             return {
                 "status": "conflicts",

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -855,7 +855,14 @@ async def rebase_continue(
 
     async with GitLockContext(timeout=30.0):
         # Stage all resolved files
-        await call_git_command_with_output("git", "add", "-A", cwd=worktree_path)
+        _, add_stderr, add_rc = await call_git_command_with_output(
+            "git", "add", "-A", cwd=worktree_path
+        )
+        if add_rc != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to stage resolved files: {add_stderr.strip()}",
+            )
 
         # Continue rebase
         stdout, stderr, rc = await call_git_command_with_output(
@@ -985,7 +992,14 @@ async def sync_continue(
 
     async with GitLockContext(timeout=30.0):
         # Stage all resolved files
-        await call_git_command_with_output("git", "add", "-A", cwd=worktree_path)
+        _, add_stderr, add_rc = await call_git_command_with_output(
+            "git", "add", "-A", cwd=worktree_path
+        )
+        if add_rc != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to stage resolved files: {add_stderr.strip()}",
+            )
 
         # Continue rebase
         stdout, stderr, rc = await call_git_command_with_output(

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -725,7 +725,10 @@ async def _complete_merge(
         "git", "rev-parse", "--abbrev-ref", "HEAD", cwd=workspace_dir
     )
     if rc != 0:
-        return {"status": "error", "detail": f"Failed to detect default branch: {stderr.strip()}"}
+        return {
+            "status": "error",
+            "detail": f"Failed to detect default branch: {stderr.strip()}",
+        }
     default_branch = stdout.strip()
 
     # Get worktree tip

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -955,9 +955,14 @@ async def sync_worktree(
             }
 
         # Rebase succeeded — worktree is now up-to-date
-        tip_stdout, _, _ = await call_git_command_with_output(
+        tip_stdout, tip_stderr, tip_rc = await call_git_command_with_output(
             "git", "rev-parse", "HEAD", cwd=worktree_path
         )
+        if tip_rc != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to get worktree HEAD after rebase: {tip_stderr.strip()}",
+            )
         return {
             "status": "success",
             "tip": tip_stdout.strip()[:12],
@@ -1006,9 +1011,14 @@ async def sync_continue(
                 detail=f"Rebase continue failed: {stderr.strip()}\n{stdout.strip()}",
             )
 
-        tip_stdout, _, _ = await call_git_command_with_output(
+        tip_stdout, tip_stderr, tip_rc = await call_git_command_with_output(
             "git", "rev-parse", "HEAD", cwd=worktree_path
         )
+        if tip_rc != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to get worktree HEAD after rebase: {tip_stderr.strip()}",
+            )
         return {
             "status": "success",
             "tip": tip_stdout.strip()[:12],

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -881,6 +881,115 @@ async def rebase_continue(
         return result
 
 
+@router.post("/worktrees/{worktree_name}/sync")
+async def sync_worktree(
+    worktree_name: str,
+    _token=Depends(verify_agent_token),
+):
+    """Rebase the worktree branch onto the default branch without modifying the
+    default branch.  This brings the worktree up-to-date with main/master.
+
+    If conflicts occur, returns status='conflicts' with the list of files.
+    Resolve them and call sync-continue."""
+    workspace_dir = _get_workspace_dir()
+    worktree_path = os.path.join(_get_worktrees_base(), worktree_name)
+
+    if not os.path.exists(worktree_path):
+        raise HTTPException(
+            status_code=404, detail=f"Worktree '{worktree_name}' not found"
+        )
+
+    async with GitLockContext(timeout=30.0):
+        # Detect default branch
+        stdout, stderr, rc = await call_git_command_with_output(
+            "git", "rev-parse", "--abbrev-ref", "HEAD", cwd=workspace_dir
+        )
+        if rc != 0:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to detect default branch: {stderr.strip()}",
+            )
+        default_branch = stdout.strip()
+
+        # Start rebase
+        stdout, stderr, rc = await call_git_command_with_output(
+            "git", "rebase", default_branch, cwd=worktree_path
+        )
+
+        if rc != 0:
+            conflict_stdout, _, _ = await call_git_command_with_output(
+                "git", "diff", "--name-only", "--diff-filter=U", cwd=worktree_path
+            )
+            conflicted_files = [f for f in conflict_stdout.strip().splitlines() if f]
+
+            return {
+                "status": "conflicts",
+                "message": "Rebase paused due to conflicts. Resolve the files and run sync-continue.",
+                "conflicted_files": conflicted_files,
+                "rebase_output": f"{stdout.strip()}\n{stderr.strip()}".strip(),
+            }
+
+        # Rebase succeeded — worktree is now up-to-date
+        tip_stdout, _, _ = await call_git_command_with_output(
+            "git", "rev-parse", "HEAD", cwd=worktree_path
+        )
+        return {
+            "status": "success",
+            "tip": tip_stdout.strip()[:12],
+        }
+
+
+@router.post("/worktrees/{worktree_name}/sync-continue")
+async def sync_continue(
+    worktree_name: str,
+    _token=Depends(verify_agent_token),
+):
+    """Continue a sync rebase after conflicts have been resolved.
+    Unlike rebase-continue, this does NOT fast-forward the default branch."""
+    worktree_path = os.path.join(_get_worktrees_base(), worktree_name)
+
+    if not os.path.exists(worktree_path):
+        raise HTTPException(
+            status_code=404, detail=f"Worktree '{worktree_name}' not found"
+        )
+
+    async with GitLockContext(timeout=30.0):
+        # Stage all resolved files
+        await call_git_command_with_output("git", "add", "-A", cwd=worktree_path)
+
+        # Continue rebase
+        stdout, stderr, rc = await call_git_command_with_output(
+            "git", "-c", "core.editor=true", "rebase", "--continue", cwd=worktree_path
+        )
+
+        if rc != 0:
+            conflict_stdout, _, _ = await call_git_command_with_output(
+                "git", "diff", "--name-only", "--diff-filter=U", cwd=worktree_path
+            )
+            conflicted_files = [f for f in conflict_stdout.strip().splitlines() if f]
+
+            if conflicted_files:
+                return {
+                    "status": "conflicts",
+                    "message": "More conflicts encountered. Resolve and run sync-continue again.",
+                    "conflicted_files": conflicted_files,
+                    "rebase_output": f"{stdout.strip()}\n{stderr.strip()}".strip(),
+                }
+
+            raise HTTPException(
+                status_code=500,
+                detail=f"Rebase continue failed: {stderr.strip()}\n{stdout.strip()}",
+            )
+
+        tip_stdout, _, _ = await call_git_command_with_output(
+            "git", "rev-parse", "HEAD", cwd=worktree_path
+        )
+        return {
+            "status": "success",
+            "tip": tip_stdout.strip()[:12],
+        }
+
+
 @router.post("/worktrees/{worktree_name}/rebase-abort")
 async def rebase_abort(
     worktree_name: str,


### PR DESCRIPTION
- Implemented POST /worktrees/{worktree_name}/sync to rebase worktree branches onto the default branch, handling conflicts and returning relevant status.
- Added POST /worktrees/{worktree_name}/sync-continue to continue the rebase process after resolving conflicts, ensuring proper error handling and status reporting.