### PR TITLE
Structured container labels and workspace-prefixed DNS

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -42,6 +42,8 @@ class DeployedAutomation(BaseModel):
     automation_url: str | None
     relative_path: str | None
     stage: str | None
+    automation_name: str | None = None
+    context: str | None = None
     version_hash: str | None = None
     replicas: int = 1
 

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -317,6 +317,20 @@ async def list_worktrees():
         # Check if .requirements.json exists
         has_requirements = os.path.exists(os.path.join(wt_path, ".requirements.json"))
 
+        # Check sync status: is the worktree branch up-to-date with main?
+        synced = False
+        if branch:
+            # Check if main's HEAD is an ancestor of the worktree branch
+            _, _, merge_base_rc = await call_git_command_with_output(
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                "HEAD",
+                branch,
+                cwd=workspace_dir,
+            )
+            synced = merge_base_rc == 0
+
         result.append(
             {
                 "name": name,
@@ -324,6 +338,7 @@ async def list_worktrees():
                 "commit_hash": commit_hash,
                 "commit_message": commit_message,
                 "has_requirements": has_requirements,
+                "synced": synced,
             }
         )
 

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -71,7 +71,6 @@ def make_hostname_label(
     return f"{ws}-{an}-{stage}" if stage else f"{ws}-{an}"
 
 
-
 class AutomationService:
     def __init__(self):
         self.bs_home = os.environ.get("BITSWAN_GITOPS_DIR", "/mnt/repo/pipeline")
@@ -1781,7 +1780,11 @@ fi
             # Build fully disambiguated image tag from structured components
             auto_name = config.get("automation_name", deployment_id)
             context = config.get("context", "")
-            full_image_tag = f"{self.workspace_name}-{context}-{auto_name}" if context else f"{self.workspace_name}-{auto_name}"
+            full_image_tag = (
+                f"{self.workspace_name}-{context}-{auto_name}"
+                if context
+                else f"{self.workspace_name}-{auto_name}"
+            )
 
             result = await image_service.create_image(
                 image_tag=full_image_tag,

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1789,8 +1789,13 @@ fi
 
             image_service = ImageService()
 
+            # Build fully disambiguated image tag from structured components
+            auto_name = config.get("automation_name", deployment_id)
+            context = config.get("context", "")
+            full_image_tag = f"{self.workspace_name}-{context}-{auto_name}" if context else f"{self.workspace_name}-{auto_name}"
+
             result = await image_service.create_image(
-                image_tag=deployment_id,
+                image_tag=full_image_tag,
                 build_context_path=source_dir,
                 checksum=tag_checksum,
             )

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -71,17 +71,6 @@ def make_hostname_label(
     return f"{ws}-{an}-{stage}" if stage else f"{ws}-{an}"
 
 
-def make_service_name(automation_name: str, context: str, stage: str) -> str:
-    """Build a Docker service name from structured components.
-
-    No string parsing — components are passed in directly.
-    """
-    an = automation_name[:MAX_NAME_LEN]
-    if context:
-        h = _short_hash(context)
-        return f"{an}-{h}-{stage}" if stage else f"{an}-{h}"
-    return f"{an}-{stage}" if stage else an
-
 
 class AutomationService:
     def __init__(self):

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -203,6 +203,10 @@ class AutomationService:
                     "relative_path", None
                 ),
                 stage=bs_yaml["deployments"][deployment_id].get("stage", "production"),
+                automation_name=bs_yaml["deployments"][deployment_id].get(
+                    "automation_name", None
+                ),
+                context=bs_yaml["deployments"][deployment_id].get("context", None),
                 version_hash=bs_yaml["deployments"][deployment_id].get(
                     "checksum", None
                 ),
@@ -265,6 +269,8 @@ class AutomationService:
                     automation_url=url,
                     relative_path=pres[deployment_id].relative_path,
                     stage=pres[deployment_id].stage,
+                    automation_name=pres[deployment_id].automation_name,
+                    context=pres[deployment_id].context,
                     version_hash=pres[deployment_id].version_hash,
                     replicas=pres[deployment_id].replicas,
                 )
@@ -1278,7 +1284,8 @@ fi
 
         dc_config = yaml.safe_load(dc_yaml)
         dep_conf = bs_yaml.get("deployments", {}).get(deployment_id, {})
-        compose_service_name = make_service_name(
+        compose_service_name = make_hostname_label(
+            self.workspace_name,
             dep_conf.get("automation_name", deployment_id),
             dep_conf.get("context", ""),
             dep_conf.get("stage", "production") or "production",
@@ -1477,7 +1484,8 @@ fi
         self._save_docker_compose(dc_yaml)
 
         dep_conf = bs_yaml.get("deployments", {}).get(deployment_id, {})
-        compose_svc = make_service_name(
+        compose_svc = make_hostname_label(
+            self.workspace_name,
             dep_conf.get("automation_name", deployment_id),
             dep_conf.get("context", ""),
             dep_conf.get("stage", "production") or "production",
@@ -2116,8 +2124,8 @@ fi
             dep_stage = conf.get("stage", "production") or "production"
             dep_automation_name = conf.get("automation_name", deployment_id)
             dep_context = conf.get("context", "")
-            service_name = make_service_name(
-                dep_automation_name, dep_context, dep_stage
+            service_name = make_hostname_label(
+                self.workspace_name, dep_automation_name, dep_context, dep_stage
             )
 
             entry = {}
@@ -2185,12 +2193,15 @@ fi
                 entry["environment"] = {"DEPLOYMENT_ID": deployment_id}
             replicas = conf.get("replicas", 1)
             if replicas <= 1:
-                entry["container_name"] = f"{self.workspace_name}__{service_name}"
+                entry["container_name"] = f"{service_name}"
             entry["restart"] = "always"
             entry["ulimits"] = {"nofile": {"soft": 65536, "hard": 65536}}
             entry["labels"] = {
                 "gitops.deployment_id": deployment_id,
                 "gitops.workspace": self.workspace_name,
+                "gitops.automation_name": dep_automation_name,
+                "gitops.context": dep_context,
+                "gitops.stage": dep_stage,
                 "gitops.intended_exposed": "false",
             }
             entry["image"] = "bitswan/pipeline-runtime-environment:latest"
@@ -2361,7 +2372,7 @@ fi
             if not network_mode:
                 if replicas > 1:
                     # Use network aliases instead of container_name for DNS round-robin
-                    alias = f"{self.workspace_name}__{deployment_id}"
+                    alias = service_name
                     entry["networks"] = {
                         net: {"aliases": [alias]} for net in networks_list
                     }

--- a/app/utils.py
+++ b/app/utils.py
@@ -384,14 +384,14 @@ def generate_workspace_url(
 def add_workspace_route_to_ingress(
     automation_name: str, context: str, stage: str, port: str
 ) -> bool:
-    from app.services.automation_service import make_service_name
+    from app.services.automation_service import make_hostname_label
 
     gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", "gitops.bitswan.space")
     workspace_name = os.environ.get("BITSWAN_WORKSPACE_NAME", "workspace-local")
     hostname = generate_workspace_url(
         workspace_name, automation_name, context, stage, gitops_domain, False
     )
-    svc_name = make_service_name(automation_name, context, stage)
+    svc_name = make_hostname_label(workspace_name, automation_name, context, stage)
     upstream = f"{svc_name}:{port}"
     return add_route_to_ingress(hostname, upstream, workspace_name)
 


### PR DESCRIPTION
## Summary
- Add `gitops.automation_name`, `gitops.context`, `gitops.stage` labels to deployed containers for unambiguous querying
- Change docker-compose service key to use `make_hostname_label()` (workspace-prefixed) so the only DNS name on the Docker network includes the workspace — removes ambiguous short-hash names
- Return `automation_name` and `context` in `get_automations()` API response
- Use fully disambiguated image tags: `internal/{workspace}-{context}-{name}`

## Test plan
- [ ] Deploy an automation and verify container has new labels (`docker inspect`)
- [ ] Verify the Docker network DNS name includes the workspace prefix
- [ ] Verify the ingress routes to the correct upstream
- [ ] Verify `GET /automations` returns `automation_name` and `context` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)