### PR TITLE
Fix synced check, SSE worktree watcher, streaming build-and-restart

### DIFF
--- a/app/deploy_manager.py
+++ b/app/deploy_manager.py
@@ -41,6 +41,7 @@ class DeployTask:
     step: DeployStep | None = None
     message: str = ""
     error: str | None = None
+    build_checksum: str | None = None
     started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None
 
@@ -52,6 +53,7 @@ class DeployTask:
             "step": self.step.value if self.step else None,
             "message": self.message,
             "error": self.error,
+            "build_checksum": self.build_checksum,
             "started_at": self.started_at.isoformat(),
             "completed_at": self.completed_at.isoformat()
             if self.completed_at

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -69,6 +69,42 @@ class WorkspaceChangeHandler(FileSystemEventHandler):
             self.schedule_update()
 
 
+class WorktreeChangeHandler(FileSystemEventHandler):
+    """Watch worktree directories for file changes and broadcast via SSE."""
+
+    def __init__(self, event_loop):
+        super().__init__()
+        self.event_loop = event_loop
+        self._debounce_task: asyncio.Task | None = None
+
+    def _schedule_broadcast(self):
+        async def _broadcast():
+            await asyncio.sleep(1)  # debounce 1s
+            try:
+                await event_broadcaster.broadcast("worktrees", {})
+            except Exception as e:
+                logger.warning("Failed to broadcast worktree change: %s", e)
+
+        def _run():
+            if self._debounce_task and not self._debounce_task.done():
+                self._debounce_task.cancel()
+            self._debounce_task = asyncio.ensure_future(_broadcast())
+
+        self.event_loop.call_soon_threadsafe(_run)
+
+    def on_created(self, event):
+        self._schedule_broadcast()
+
+    def on_deleted(self, event):
+        self._schedule_broadcast()
+
+    def on_modified(self, event):
+        self._schedule_broadcast()
+
+    def on_moved(self, event):
+        self._schedule_broadcast()
+
+
 async def _broadcast_automations_after_delay():
     """Debounced broadcast of automation state after Docker events settle."""
     await asyncio.sleep(0.5)
@@ -113,6 +149,7 @@ async def _docker_event_watcher():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     observer = None
+    worktree_observer = None
     watcher_task: asyncio.Task | None = None
 
     scheduler = AsyncIOScheduler(timezone="UTC")
@@ -146,6 +183,15 @@ async def lifespan(app: FastAPI):
             print(f"Started watching workspace directory: {workspace_dir}")
         else:
             print(f"Workspace directory does not exist: {workspace_dir}")
+
+        # Watch worktree directories for file changes → SSE push
+        worktrees_dir = os.path.join(workspace_dir, "worktrees")
+        if os.path.exists(worktrees_dir):
+            wt_handler = WorktreeChangeHandler(asyncio.get_event_loop())
+            worktree_observer = Observer()
+            worktree_observer.schedule(wt_handler, worktrees_dir, recursive=True)
+            worktree_observer.start()
+            print(f"Started watching worktrees directory: {worktrees_dir}")
 
         # Clean up completed/failed deploy tasks every 10 minutes
         scheduler.add_job(
@@ -203,3 +249,6 @@ async def lifespan(app: FastAPI):
             observer.stop()
             # Run blocking join in executor to avoid blocking event loop
             await asyncio.to_thread(observer.join)
+        if worktree_observer:
+            worktree_observer.stop()
+            await asyncio.to_thread(worktree_observer.join)

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -569,6 +569,12 @@ async def build_and_restart_deployment(
                     build_iter = await asyncio.to_thread(_build)
                     build_error = None
                     for line in build_iter:
+                        # Strip ANSI escape sequences from stream output
+                        # to prevent terminal clears/resets on the client
+                        if "stream" in line:
+                            line["stream"] = re.sub(
+                                r"\x1b\[[0-9;]*[a-zA-Z]", "", line["stream"]
+                            )
                         yield _json.dumps(line) + "\n"
                         if "error" in line:
                             build_error = line["error"]

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -516,117 +516,81 @@ async def build_and_restart_deployment(
     automation_service: AutomationService = Depends(get_automation_service),
     _token=Depends(verify_agent_token),
 ):
+    """Build image and restart deployment. Streams progress as text/plain."""
     _validate_deployment_id(deployment_id)
 
-    # Trigger deploy which handles image build + restart
-    from app.deploy_manager import deploy_manager, DeployStatus
+    from app.deploy_manager import deploy_manager
 
-    # Guard: reject if already deploying
     if deploy_manager.is_deploying(deployment_id):
         raise HTTPException(
             status_code=409,
             detail=f"Deployment {deployment_id} is already in progress",
         )
 
-    task = await deploy_manager.create_task(deployment_id)
-    if task is None:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Deployment {deployment_id} is already in progress",
-        )
+    async def _stream():
+        from app.services.automation_service import read_bitswan_yaml
 
-    # Spawn background deploy task
-    async def _run_build_and_restart():
-        try:
-            await deploy_manager.update_task(
-                task.task_id,
-                status=DeployStatus.IN_PROGRESS,
-                message="Looking up deployment...",
+        yield "Looking up deployment...\n"
+        bs_yaml = read_bitswan_yaml(automation_service.gitops_dir)
+        dep_conf = (bs_yaml or {}).get("deployments", {}).get(deployment_id, {})
+        relative_path = dep_conf.get("relative_path", "")
+
+        # Build image if image/ directory exists
+        if relative_path:
+            source_dir = os.path.join(
+                automation_service.workspace_repo_dir, relative_path
             )
+            image_dir = os.path.join(source_dir, "image")
+            if os.path.isdir(image_dir) and os.path.isfile(
+                os.path.join(image_dir, "Dockerfile")
+            ):
+                yield "Building image...\n"
+                from app.services.image_service import ImageService
 
-            # Look up deployment config to find source path
-            from app.services.automation_service import read_bitswan_yaml
-
-            bs_yaml = read_bitswan_yaml(automation_service.gitops_dir)
-            dep_conf = (bs_yaml or {}).get("deployments", {}).get(deployment_id, {})
-            relative_path = dep_conf.get("relative_path", "")
-
-            # Build image if image/ directory exists in the source
-            if relative_path:
-                source_dir = os.path.join(
-                    automation_service.workspace_repo_dir, relative_path
+                image_service = ImageService()
+                auto_name = os.path.basename(source_dir)
+                result = await image_service.create_image(
+                    image_tag=auto_name,
+                    build_context_path=image_dir,
                 )
-                image_dir = os.path.join(source_dir, "image")
-                if os.path.isdir(image_dir) and os.path.isfile(
-                    os.path.join(image_dir, "Dockerfile")
-                ):
-                    await deploy_manager.update_task(
-                        task.task_id, message="Building image..."
-                    )
-                    from app.services.image_service import ImageService
+                tag = result.get("tag", "")
+                checksum = tag.split(":sha", 1)[1] if ":sha" in tag else None
 
-                    image_service = ImageService()
-                    auto_name = os.path.basename(source_dir)
-                    result = await image_service.create_image(
-                        image_tag=auto_name,
-                        build_context_path=image_dir,
-                    )
-                    tag = result.get("tag", "")
-                    checksum = tag.split(":sha", 1)[1] if ":sha" in tag else None
+                if checksum:
+                    async for chunk in image_service.stream_build_logs(checksum):
+                        yield chunk
 
-                    # Wait for the build to finish, streaming log lines
-                    # as task messages
-                    if checksum:
-                        last_line = ""
-                        async for chunk in image_service.stream_build_logs(checksum):
-                            for line in chunk.splitlines():
-                                line = line.strip()
-                                if line and line != last_line:
-                                    last_line = line
-                                    await deploy_manager.update_task(
-                                        task.task_id,
-                                        message=f"Building: {line[:120]}",
-                                    )
+                    build_status = image_service._get_build_status(checksum)
+                    if build_status == "failed":
+                        yield "ERROR: Image build failed\n"
+                        return
 
-                        # Check if build succeeded
-                        build_status = image_service._get_build_status(checksum)
-                        if build_status == "failed":
-                            raise Exception(f"Image build failed for {auto_name}")
+                yield f"Image built: {tag}\n"
 
-                    await deploy_manager.update_task(
-                        task.task_id,
-                        message=f"Image built: {tag}",
-                    )
-
-            await deploy_manager.update_task(task.task_id, message="Deploying...")
+        yield "Deploying...\n"
+        try:
             await automation_service.deploy_automation(
                 deployment_id=deployment_id, stage="live-dev"
             )
-            await deploy_manager.update_task(
-                task.task_id,
-                status=DeployStatus.COMPLETED,
-                message="Build and restart completed",
-            )
+            yield "Deploy completed successfully\n"
         except Exception as exc:
-            logger.exception(
-                "Build and restart failed for %s (task %s)",
-                deployment_id,
-                task.task_id,
-            )
-            await deploy_manager.update_task(
-                task.task_id,
-                status=DeployStatus.FAILED,
-                error=str(exc),
-                message="Build and restart failed",
-            )
+            yield f"ERROR: {exc}\n"
 
-    asyncio.create_task(_run_build_and_restart())
+    return StreamingResponse(_stream(), media_type="text/plain")
 
-    return {
-        "task_id": task.task_id,
-        "deployment_id": deployment_id,
-        "status": "pending",
-    }
+
+@router.get("/images/builds/{checksum}/stream")
+async def stream_agent_build_logs(
+    checksum: str,
+    _token=Depends(verify_agent_token),
+):
+    """Stream image build logs (proxied from image service)."""
+    from app.services.image_service import ImageService
+
+    image_service = ImageService()
+    return StreamingResponse(
+        image_service.stream_build_logs(checksum), media_type="text/plain"
+    )
 
 
 @router.get("/deployments/{deployment_id}/deploy-status")

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -550,9 +550,35 @@ async def build_and_restart_deployment(
             if os.path.isdir(image_dir) and os.path.isfile(
                 os.path.join(image_dir, "Dockerfile")
             ):
+                from app.utils import calculate_git_tree_hash
+                import toml as _toml
+
+                # Compute content hash and build disambiguated tag
+                # matching the editor scheme: internal/{ws}-{bp}-{name}:sha{hash}
+                checksum = await calculate_git_tree_hash(image_dir)
                 auto_name = os.path.basename(source_dir)
-                tag = f"internal/{auto_name}"
-                yield _ndjson(status=f"Building image {tag}...")
+                ws_name = automation_service.workspace_name or "workspace"
+                # Extract BP name from relative_path
+                # e.g. "worktrees/test2/foobar/backend" → bp = "foobar"
+                # e.g. "foobar/backend" → bp = "foobar"
+                rel_parts = relative_path.replace("\\", "/").split("/")
+                if len(rel_parts) >= 2 and rel_parts[0] == "worktrees":
+                    bp_name = rel_parts[2] if len(rel_parts) >= 4 else ""
+                else:
+                    bp_name = rel_parts[0] if len(rel_parts) >= 2 else ""
+                bp_sanitized = (
+                    re.sub(r"[^a-z0-9-]", "-", bp_name.lower()).strip("-")
+                    if bp_name
+                    else ""
+                )
+                full_image_name = (
+                    f"{ws_name}-{bp_sanitized}-{auto_name}"
+                    if bp_sanitized
+                    else f"{ws_name}-{auto_name}"
+                )
+                full_tag = f"internal/{full_image_name}:sha{checksum}"
+
+                yield _ndjson(status=f"Building image {full_tag}...")
 
                 # Build using Docker API directly — streams ndjson
                 client = _docker.from_env()
@@ -561,7 +587,7 @@ async def build_and_restart_deployment(
                     def _build():
                         return client.api.build(
                             path=image_dir,
-                            tag=tag,
+                            tag=full_tag,
                             rm=True,
                             decode=True,
                         )
@@ -569,8 +595,6 @@ async def build_and_restart_deployment(
                     build_iter = await asyncio.to_thread(_build)
                     build_error = None
                     for line in build_iter:
-                        # Strip ANSI escape sequences from stream output
-                        # to prevent terminal clears/resets on the client
                         if "stream" in line:
                             line["stream"] = re.sub(
                                 r"\x1b\[[0-9;]*[a-zA-Z]", "", line["stream"]
@@ -584,7 +608,17 @@ async def build_and_restart_deployment(
                 if build_error:
                     return
 
-                yield _ndjson(status=f"Image built: {tag}")
+                # Update automation.toml with the new image tag
+                automation_toml_path = os.path.join(source_dir, "automation.toml")
+                if os.path.isfile(automation_toml_path):
+                    with open(automation_toml_path, "r") as f:
+                        config = _toml.load(f)
+                    config.setdefault("deployment", {})["image"] = full_tag
+                    with open(automation_toml_path, "w") as f:
+                        _toml.dump(config, f)
+                    yield _ndjson(status=f"Updated automation.toml: image = {full_tag}")
+
+                yield _ndjson(status=f"Image built: {full_tag}")
 
         yield _ndjson(status="Deploying...")
         try:

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -519,7 +519,7 @@ async def build_and_restart_deployment(
     _validate_deployment_id(deployment_id)
 
     # Trigger deploy which handles image build + restart
-    from app.deploy_manager import deploy_manager
+    from app.deploy_manager import deploy_manager, DeployStatus
 
     # Guard: reject if already deploying
     if deploy_manager.is_deploying(deployment_id):
@@ -539,13 +539,17 @@ async def build_and_restart_deployment(
     async def _run_build_and_restart():
         try:
             await deploy_manager.update_task(
-                task.task_id, message="Starting build and restart..."
+                task.task_id,
+                status=DeployStatus.IN_PROGRESS,
+                message="Starting build and restart...",
             )
             await automation_service.deploy_automation(
                 deployment_id=deployment_id, stage="live-dev"
             )
             await deploy_manager.update_task(
-                task.task_id, message="Build and restart completed"
+                task.task_id,
+                status=DeployStatus.COMPLETED,
+                message="Build and restart completed",
             )
         except Exception as exc:
             logger.exception(
@@ -554,7 +558,10 @@ async def build_and_restart_deployment(
                 task.task_id,
             )
             await deploy_manager.update_task(
-                task.task_id, error=str(exc), message="Build and restart failed"
+                task.task_id,
+                status=DeployStatus.FAILED,
+                error=str(exc),
+                message="Build and restart failed",
             )
 
     asyncio.create_task(_run_build_and_restart())

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -516,7 +516,7 @@ async def build_and_restart_deployment(
     automation_service: AutomationService = Depends(get_automation_service),
     _token=Depends(verify_agent_token),
 ):
-    """Build image and restart deployment. Streams progress as text/plain."""
+    """Build image and restart deployment. Streams ndjson progress."""
     _validate_deployment_id(deployment_id)
 
     from app.deploy_manager import deploy_manager
@@ -527,10 +527,16 @@ async def build_and_restart_deployment(
             detail=f"Deployment {deployment_id} is already in progress",
         )
 
+    import json as _json
+    import docker as _docker
+
     async def _stream():
         from app.services.automation_service import read_bitswan_yaml
 
-        yield "Looking up deployment...\n"
+        def _ndjson(**kwargs):
+            return _json.dumps(kwargs) + "\n"
+
+        yield _ndjson(status="Looking up deployment...")
         bs_yaml = read_bitswan_yaml(automation_service.gitops_dir)
         dep_conf = (bs_yaml or {}).get("deployments", {}).get(deployment_id, {})
         relative_path = dep_conf.get("relative_path", "")
@@ -544,39 +550,46 @@ async def build_and_restart_deployment(
             if os.path.isdir(image_dir) and os.path.isfile(
                 os.path.join(image_dir, "Dockerfile")
             ):
-                yield "Building image...\n"
-                from app.services.image_service import ImageService
-
-                image_service = ImageService()
                 auto_name = os.path.basename(source_dir)
-                result = await image_service.create_image(
-                    image_tag=auto_name,
-                    build_context_path=image_dir,
-                )
-                tag = result.get("tag", "")
-                checksum = tag.split(":sha", 1)[1] if ":sha" in tag else None
+                tag = f"internal/{auto_name}"
+                yield _ndjson(status=f"Building image {tag}...")
 
-                if checksum:
-                    async for chunk in image_service.stream_build_logs(checksum):
-                        yield chunk
+                # Build using Docker API directly — streams ndjson
+                client = _docker.from_env()
+                try:
 
-                    build_status = image_service._get_build_status(checksum)
-                    if build_status == "failed":
-                        yield "ERROR: Image build failed\n"
-                        return
+                    def _build():
+                        return client.api.build(
+                            path=image_dir,
+                            tag=tag,
+                            rm=True,
+                            decode=True,
+                        )
 
-                yield f"Image built: {tag}\n"
+                    build_iter = await asyncio.to_thread(_build)
+                    build_error = None
+                    for line in build_iter:
+                        yield _json.dumps(line) + "\n"
+                        if "error" in line:
+                            build_error = line["error"]
+                finally:
+                    client.close()
 
-        yield "Deploying...\n"
+                if build_error:
+                    return
+
+                yield _ndjson(status=f"Image built: {tag}")
+
+        yield _ndjson(status="Deploying...")
         try:
             await automation_service.deploy_automation(
                 deployment_id=deployment_id, stage="live-dev"
             )
-            yield "Deploy completed successfully\n"
+            yield _ndjson(status="Deploy completed successfully")
         except Exception as exc:
-            yield f"ERROR: {exc}\n"
+            yield _ndjson(error=str(exc))
 
-    return StreamingResponse(_stream(), media_type="text/plain")
+    return StreamingResponse(_stream(), media_type="application/x-ndjson")
 
 
 @router.get("/images/builds/{checksum}/stream")

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -541,8 +541,43 @@ async def build_and_restart_deployment(
             await deploy_manager.update_task(
                 task.task_id,
                 status=DeployStatus.IN_PROGRESS,
-                message="Starting build and restart...",
+                message="Looking up deployment...",
             )
+
+            # Look up deployment config to find source path
+            from app.services.automation_service import read_bitswan_yaml
+
+            bs_yaml = read_bitswan_yaml(automation_service.gitops_dir)
+            dep_conf = (bs_yaml or {}).get("deployments", {}).get(deployment_id, {})
+            relative_path = dep_conf.get("relative_path", "")
+
+            # Build image if image/ directory exists in the source
+            if relative_path:
+                source_dir = os.path.join(
+                    automation_service.workspace_repo_dir, relative_path
+                )
+                image_dir = os.path.join(source_dir, "image")
+                if os.path.isdir(image_dir) and os.path.isfile(
+                    os.path.join(image_dir, "Dockerfile")
+                ):
+                    await deploy_manager.update_task(
+                        task.task_id, message="Building image..."
+                    )
+                    from app.services.image_service import ImageService
+
+                    image_service = ImageService()
+                    # Use automation name for the image tag
+                    auto_name = os.path.basename(source_dir)
+                    result = await image_service.create_image(
+                        image_tag=auto_name,
+                        build_context_path=image_dir,
+                    )
+                    await deploy_manager.update_task(
+                        task.task_id,
+                        message=f"Image built: {result.get('tag', auto_name)}",
+                    )
+
+            await deploy_manager.update_task(task.task_id, message="Deploying...")
             await automation_service.deploy_automation(
                 deployment_id=deployment_id, stage="live-dev"
             )

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -566,6 +566,23 @@ async def build_and_restart_deployment(
     }
 
 
+@router.get("/deployments/{deployment_id}/deploy-status")
+async def get_deployment_status(
+    deployment_id: str,
+    _token=Depends(verify_agent_token),
+):
+    """Get the active deploy task for a deployment, if any."""
+    from app.deploy_manager import deploy_manager
+
+    task_id = deploy_manager._active_deploys.get(deployment_id)
+    if not task_id:
+        return {"deploying": False}
+    task = deploy_manager.get_task(task_id)
+    if not task:
+        return {"deploying": False}
+    return {"deploying": True, **task.to_dict()}
+
+
 # --- Worktree commit endpoint ---
 
 

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -566,15 +566,36 @@ async def build_and_restart_deployment(
                     from app.services.image_service import ImageService
 
                     image_service = ImageService()
-                    # Use automation name for the image tag
                     auto_name = os.path.basename(source_dir)
                     result = await image_service.create_image(
                         image_tag=auto_name,
                         build_context_path=image_dir,
                     )
+                    tag = result.get("tag", "")
+                    checksum = tag.split(":sha", 1)[1] if ":sha" in tag else None
+
+                    # Wait for the build to finish, streaming log lines
+                    # as task messages
+                    if checksum:
+                        last_line = ""
+                        async for chunk in image_service.stream_build_logs(checksum):
+                            for line in chunk.splitlines():
+                                line = line.strip()
+                                if line and line != last_line:
+                                    last_line = line
+                                    await deploy_manager.update_task(
+                                        task.task_id,
+                                        message=f"Building: {line[:120]}",
+                                    )
+
+                        # Check if build succeeded
+                        build_status = image_service._get_build_status(checksum)
+                        if build_status == "failed":
+                            raise Exception(f"Image build failed for {auto_name}")
+
                     await deploy_manager.update_task(
                         task.task_id,
-                        message=f"Image built: {result.get('tag', auto_name)}",
+                        message=f"Image built: {tag}",
                     )
 
             await deploy_manager.update_task(task.task_id, message="Deploying...")

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -323,17 +323,27 @@ async def list_worktrees():
         if branch:
             # Check main's HEAD is ancestor of worktree (worktree has main's changes)
             _, _, main_in_wt_rc = await call_git_command_with_output(
-                "git", "merge-base", "--is-ancestor", "HEAD", branch,
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                "HEAD",
+                branch,
                 cwd=workspace_dir,
             )
             # Check worktree is ancestor of main (no commits ahead)
             _, _, wt_in_main_rc = await call_git_command_with_output(
-                "git", "merge-base", "--is-ancestor", branch, "HEAD",
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                branch,
+                "HEAD",
                 cwd=workspace_dir,
             )
             # Check for uncommitted changes in the worktree
             diff_stdout, _, diff_rc = await call_git_command_with_output(
-                "git", "status", "--porcelain",
+                "git",
+                "status",
+                "--porcelain",
                 cwd=wt_path,
             )
             has_changes = bool(diff_stdout and diff_stdout.strip())

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -317,19 +317,27 @@ async def list_worktrees():
         # Check if .requirements.json exists
         has_requirements = os.path.exists(os.path.join(wt_path, ".requirements.json"))
 
-        # Check sync status: is the worktree branch up-to-date with main?
+        # Check sync status: worktree is synced only when its branch tip
+        # matches main AND there are no uncommitted changes.
         synced = False
         if branch:
-            # Check if main's HEAD is an ancestor of the worktree branch
-            _, _, merge_base_rc = await call_git_command_with_output(
-                "git",
-                "merge-base",
-                "--is-ancestor",
-                "HEAD",
-                branch,
+            # Check main's HEAD is ancestor of worktree (worktree has main's changes)
+            _, _, main_in_wt_rc = await call_git_command_with_output(
+                "git", "merge-base", "--is-ancestor", "HEAD", branch,
                 cwd=workspace_dir,
             )
-            synced = merge_base_rc == 0
+            # Check worktree is ancestor of main (no commits ahead)
+            _, _, wt_in_main_rc = await call_git_command_with_output(
+                "git", "merge-base", "--is-ancestor", branch, "HEAD",
+                cwd=workspace_dir,
+            )
+            # Check for uncommitted changes in the worktree
+            diff_stdout, _, diff_rc = await call_git_command_with_output(
+                "git", "status", "--porcelain",
+                cwd=wt_path,
+            )
+            has_changes = bool(diff_stdout and diff_stdout.strip())
+            synced = main_in_wt_rc == 0 and wt_in_main_rc == 0 and not has_changes
 
         result.append(
             {


### PR DESCRIPTION
## Summary
- Fix synced check: false when worktree has new commits or uncommitted changes
- Add worktree file watcher that broadcasts SSE events on changes
- Rewrite build-and-restart as streaming ndjson response with Docker build output
- Use correct image tag scheme (`internal/{ws}-{bp}-{name}:sha{hash}`) and update automation.toml after build
- Fix task status (COMPLETED/FAILED) so CLI doesn't hang
- Add deploy-status endpoint by deployment_id
- Strip ANSI escape sequences from Docker build stream

## Test plan
- [ ] Worktree shows not-synced after committing
- [ ] `bitswan-coding-agent deployments build-and-restart` streams build logs
- [ ] automation.toml gets updated with new image tag after build
- [ ] Deploy uses correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)