### PR TITLE
DRY: single resolve_automation_config, fix live-dev services

### DIFF
--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -201,21 +201,9 @@ async def deploy_automation(
     checksum: str | None = Form(None),
     stage: str | None = Form(None),
     relative_path: str | None = Form(None),
-    # Automation config values (sent by extension for live-dev)
-    image: str | None = Form(None),
-    expose: str | None = Form(None),  # "true" or "false" as string from form
-    port: str | None = Form(None),  # port as string from form
-    mount_path: str | None = Form(None),
-    secret_groups: str | None = Form(None),  # comma-separated list of secret groups
-    automation_id: str | None = Form(None),  # Unique automation ID for Keycloak
-    auth: str | None = Form(None),  # "true" or "false" - enable Keycloak auth
-    allowed_domains: str | None = Form(
-        None
-    ),  # comma-separated list of CORS allowed domains
-    expose_to: str | None = Form(None),  # JSON list: ["/Example Org/admin"]
     services: str | None = Form(None),  # JSON: {"kafka": {"enabled": true}, ...}
-    replicas: str | None = Form(None),  # replicas as string from form
-    deployed_by: str | None = Form(None),  # email of the user who triggered the deploy
+    replicas: str | None = Form(None),
+    deployed_by: str | None = Form(None),
     automation_name_field: str | None = Form(None, alias="automation_name"),
     context_field: str | None = Form(None, alias="context"),
     automation_service: AutomationService = Depends(get_automation_service),
@@ -228,33 +216,18 @@ async def deploy_automation(
         )
 
     # Validate stage if provided
-    if stage is not None and stage not in ["dev", "staging", "production", "live-dev"]:
+    if stage is not None and stage not in [
+        "dev",
+        "staging",
+        "production",
+        "live-dev",
+    ]:
         raise HTTPException(
             status_code=400,
             detail="Stage must be one of: dev, staging, production, live-dev",
         )
-    # Convert form values to proper types
-    expose_bool = expose.lower() == "true" if expose else None
-    port_int = int(port) if port else None
-    secret_groups_list = (
-        [g.strip() for g in secret_groups.split(",") if g.strip()]
-        if secret_groups
-        else None
-    )
-    auth_bool = auth.lower() == "true" if auth else None
-    allowed_domains_list = (
-        [d.strip() for d in allowed_domains.split(",") if d.strip()]
-        if allowed_domains
-        else None
-    )
-    replicas_int = int(replicas) if replicas else None
 
-    expose_to_list = None
-    if expose_to:
-        try:
-            expose_to_list = _json.loads(expose_to)
-        except _json.JSONDecodeError:
-            raise HTTPException(status_code=400, detail="Invalid expose_to JSON")
+    replicas_int = int(replicas) if replicas else None
 
     services_dict = None
     if services:
@@ -278,15 +251,6 @@ async def deploy_automation(
         relative_path=relative_path,
         automation_name=automation_name_field,
         context=context_field,
-        image=image,
-        expose=expose_bool,
-        expose_to=expose_to_list,
-        port=port_int,
-        mount_path=mount_path,
-        secret_groups=secret_groups_list,
-        automation_id=automation_id,
-        auth=auth_bool,
-        allowed_domains=allowed_domains_list,
         services=services_dict,
         replicas=replicas_int,
         deployed_by=deployed_by,

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1069,6 +1069,29 @@ fi
         except DockerError:
             return None
 
+    def resolve_automation_config(self, deployment_conf: dict) -> "AutomationConfig":
+        """Resolve AutomationConfig for a deployment from the canonical source.
+
+        For live-dev: reads automation.toml from the workspace source directory.
+        For promoted stages: reads from the gitops checksum directory.
+        Single source of truth — used by both deploy_automation (service auto-enable)
+        and generate_docker_compose (container config).
+        """
+        stage = deployment_conf.get("stage", "production") or "production"
+        relative_path = deployment_conf.get("relative_path", "")
+
+        if stage == "live-dev" and relative_path:
+            source_dir = os.path.join(self.workspace_repo_dir, relative_path)
+        else:
+            source = (
+                deployment_conf.get("source") or deployment_conf.get("checksum") or ""
+            )
+            source_dir = os.path.join(self.gitops_dir, source) if source else ""
+
+        if source_dir and os.path.exists(source_dir):
+            return read_automation_config(source_dir)
+        return AutomationConfig()
+
     async def deploy_automation(
         self,
         deployment_id: str,
@@ -1078,16 +1101,6 @@ fi
         # Structured name components (for shortened hostnames/service names)
         automation_name: str | None = None,
         context: str | None = None,
-        # Automation config values (for live-dev, sent by extension)
-        image: str | None = None,
-        expose: bool | None = None,
-        expose_to: list[str] | None = None,
-        port: int | None = None,
-        mount_path: str | None = None,
-        secret_groups: list[str] | None = None,
-        automation_id: str | None = None,
-        auth: bool | None = None,
-        allowed_domains: list[str] | None = None,
         services: dict | None = None,
         replicas: int | None = None,
         deployed_by: str | None = None,
@@ -1123,15 +1136,6 @@ fi
                 checksum,
                 stage,
                 relative_path,
-                image,
-                expose,
-                expose_to,
-                port,
-                mount_path,
-                secret_groups,
-                automation_id,
-                auth,
-                allowed_domains,
                 services,
                 replicas,
             ]
@@ -1175,25 +1179,6 @@ fi
             if relative_path is not None:
                 deployment_config["relative_path"] = relative_path
 
-            # Store automation config values (for live-dev deployments)
-            if image is not None:
-                deployment_config["image"] = image
-            if expose is not None:
-                deployment_config["expose"] = expose
-            if expose_to is not None:
-                deployment_config["expose_to"] = expose_to
-            if port is not None:
-                deployment_config["port"] = port
-            if mount_path is not None:
-                deployment_config["mount_path"] = mount_path
-            if secret_groups is not None:
-                deployment_config["secret_groups"] = secret_groups
-            if automation_id is not None:
-                deployment_config["id"] = automation_id
-            if auth is not None:
-                deployment_config["auth"] = auth
-            if allowed_domains is not None:
-                deployment_config["allowed_domains"] = allowed_domains
             if services is not None:
                 deployment_config["services"] = services
             if replicas is not None:
@@ -1219,30 +1204,19 @@ fi
             bs_yaml = read_bitswan_yaml(self.gitops_dir)
 
         # Auto-enable declared services for this deployment.
-        # Check bitswan.yaml first, then fall back to automation config on disk
-        # so that promoted deployments (which don't have services in bitswan.yaml)
-        # still trigger service auto-enable.
         deployment_conf = bs_yaml.get("deployments", {}).get(deployment_id, {}) or {}
         deploy_services = services or deployment_conf.get("services")
         deploy_stage = stage or deployment_conf.get("stage") or "production"
         if deploy_stage == "":
             deploy_stage = "production"
 
-        if not deploy_services and deploy_stage != "live-dev":
-            # Read services from automation config on disk
-            source = (
-                deployment_conf.get("source")
-                or deployment_conf.get("checksum")
-                or deployment_id
-            )
-            source_dir = os.path.join(self.gitops_dir, source)
-            if os.path.exists(source_dir):
-                auto_conf = read_automation_config(source_dir)
-                if auto_conf.services:
-                    deploy_services = {
-                        svc_name: {"enabled": svc_dep.enabled}
-                        for svc_name, svc_dep in auto_conf.services.items()
-                    }
+        if not deploy_services:
+            auto_conf = self.resolve_automation_config(deployment_conf)
+            if auto_conf.services:
+                deploy_services = {
+                    svc_name: {"enabled": svc_dep.enabled}
+                    for svc_name, svc_dep in auto_conf.services.items()
+                }
 
         if deploy_services:
             await _report("enabling_services", "Enabling declared services...")
@@ -2136,30 +2110,22 @@ fi
                 stage = "production"
             relative_path = conf.get("relative_path")
 
-            if stage == "live-dev" and relative_path:
-                # For live-dev, read automation.toml directly from the workspace
-                live_dev_source_dir = os.path.join(
-                    self.workspace_repo_dir, relative_path
-                )
-                if not os.path.isdir(live_dev_source_dir):
-                    continue
-                automation_config = read_automation_config(live_dev_source_dir)
-                if not automation_config.image:
-                    continue
-                pipeline_conf = None
-            elif stage == "live-dev":
+            automation_config = self.resolve_automation_config(conf)
+            if stage == "live-dev" and not automation_config.image:
+                continue
+            elif stage == "live-dev" and not relative_path:
                 raise HTTPException(
                     status_code=500,
                     detail=f"Live-dev deployment {deployment_id} is missing relative_path",
                 )
-            elif not os.path.exists(source_dir):
+            elif stage != "live-dev" and not os.path.exists(source_dir):
                 raise HTTPException(
                     status_code=500,
                     detail=f"Deployment directory {source_dir} does not exist",
                 )
-            else:
+            pipeline_conf = None
+            if stage != "live-dev" and os.path.exists(source_dir):
                 pipeline_conf = read_pipeline_conf(source_dir)
-                automation_config = read_automation_config(source_dir)
 
             # Ensure services from automation config on disk are reflected in
             # the deployment conf so _merge_infra_services() can discover them.


### PR DESCRIPTION
## Summary
- Add `resolve_automation_config()` — single method that reads automation.toml from the correct source for any deployment stage (workspace dir for live-dev, gitops dir for promoted)
- Remove dead bitswan.yaml field storage: image, expose, port, mount_path, secret_groups, auth, allowed_domains, expose_to were written but never read back by generate_docker_compose
- Remove dead Form params from the deploy endpoint (server reads config from disk)
- Service auto-enable now works for live-dev (was previously skipped)
- generate_docker_compose uses the same resolver

**-70 lines of dead code removed.**

## Test plan
- [ ] Live-dev deploy: postgres/minio start automatically
- [ ] Promoted deploy (dev/staging): still reads config correctly
- [ ] Services auto-enable for all stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)