### PR TITLE
Add VPN route classification for dual-ingress

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -2388,6 +2388,22 @@ fi
             if expose_to_groups:
                 expose = True
 
+            # Determine ingress target for VPN routing
+            vpn_enabled = os.environ.get("BITSWAN_VPN_ENABLED", "") == "true"
+            if vpn_enabled:
+                if stage in ("live-dev", "dev"):
+                    ingress_target = "internal"
+                elif expose_to_groups and automation_config.expose_to_internet:
+                    ingress_target = "external"
+                elif expose_to_groups:
+                    ingress_target = "internal"
+                elif expose and stage in ("staging", "production"):
+                    ingress_target = "external"
+                else:
+                    ingress_target = "internal"
+            else:
+                ingress_target = ""
+
             if expose and port:
                 # Set URL env vars for exposed automations
                 # Shorten hostname if it would exceed DNS 63-char label limit
@@ -2448,6 +2464,7 @@ fi
                         dep_context,
                         dep_stage,
                         self.oauth2_proxy_port,
+                        ingress_target=ingress_target,
                     ):
                         logger.warning(
                             f"Failed to add ingress route for {deployment_id} (oauth2 proxy port)"
@@ -2456,7 +2473,11 @@ fi
                 else:
                     entry["labels"]["gitops.intended_exposed"] = "true"
                     if not add_workspace_route_to_ingress(
-                        dep_automation_name, dep_context, dep_stage, port
+                        dep_automation_name,
+                        dep_context,
+                        dep_stage,
+                        port,
+                        ingress_target=ingress_target,
                     ):
                         logger.warning(
                             f"Failed to add ingress route for {deployment_id} — "

--- a/app/utils.py
+++ b/app/utils.py
@@ -112,6 +112,9 @@ class AutomationConfig:
     allowed_domains: list[str] | None = None
     # Infrastructure service dependencies
     services: dict[str, ServiceDependency] | None = None
+    # When True, expose_to automations are also routed via the external
+    # (internet-facing) ingress, not just the VPN ingress.
+    expose_to_internet: bool = False
     # Use host network for external access (Selenium testing)
     external_testing_network: bool = False
 
@@ -193,6 +196,7 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
             ),
             allowed_domains=allowed_domains,
             services=services,
+            expose_to_internet=deployment.get("expose_to_internet", False),
             external_testing_network=deployment.get("external-testing-network", False),
         )
     except Exception:
@@ -382,7 +386,11 @@ def generate_workspace_url(
 
 
 def add_workspace_route_to_ingress(
-    automation_name: str, context: str, stage: str, port: str
+    automation_name: str,
+    context: str,
+    stage: str,
+    port: str,
+    ingress_target: str = "",
 ) -> bool:
     from app.services.automation_service import make_hostname_label
 
@@ -393,7 +401,7 @@ def add_workspace_route_to_ingress(
     )
     svc_name = make_hostname_label(workspace_name, automation_name, context, stage)
     upstream = f"{svc_name}:{port}"
-    return add_route_to_ingress(hostname, upstream, workspace_name)
+    return add_route_to_ingress(hostname, upstream, workspace_name, ingress_target)
 
 
 def _ingress_client_and_base() -> tuple:
@@ -418,13 +426,18 @@ def _ingress_client_and_base() -> tuple:
 
 
 def add_route_to_ingress(
-    hostname: str, upstream: str, workspace_name: str = ""
+    hostname: str,
+    upstream: str,
+    workspace_name: str = "",
+    ingress_target: str = "",
 ) -> bool:
     body = {
         "hostname": hostname,
         "upstream": upstream,
         "workspace_name": workspace_name,
     }
+    if ingress_target:
+        body["ingress_target"] = ingress_target
     try:
         client, base = _ingress_client_and_base()
         with client:


### PR DESCRIPTION
## Summary
Fourth and final PR in the WireGuard VPN series (gitops side).

- Add `expose_to_internet: bool` to `AutomationConfig` (parsed from `automation.toml`)
- Add `ingress_target` parameter to `add_route_to_ingress()` and `add_workspace_route_to_ingress()`
- Classify routes during docker-compose generation when `BITSWAN_VPN_ENABLED=true`:
  - dev/live-dev → `"internal"` (VPN only)
  - staging/production with `expose=true` → `"external"` (internet)
  - `expose_to` + `expose_to_internet=true` → `"external"`
  - `expose_to` without `expose_to_internet` → `"internal"`
- When VPN not enabled → empty string (backward compatible, single ingress)

## automation.toml example
```toml
[deployment]
expose = true
expose_to_internet = true  # also route via external ingress
```

## Series
1. Dual-ingress infrastructure (bitswan-automation-server#328)
2. WireGuard server management (bitswan-automation-server#329)
3. VPN admin UI and magic links (bitswan-automation-server#330)
4. **This PR: Route classification in gitops**

## Test plan
- [ ] Without VPN: routes work exactly as before (ingress_target empty)
- [ ] With VPN: staging expose=true goes to external, dev goes to internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)