### PR TITLE
Security: constant-time tokens, path traversal protection, zip slip fix

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,4 @@
+import hmac
 import os
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -8,7 +9,9 @@ from app.services.jupyter_service import JupyterService
 
 def verify_token(credentials: HTTPAuthorizationCredentials = Security(HTTPBearer())):
     secret_token = os.environ.get("BITSWAN_GITOPS_SECRET")
-    if credentials.scheme != "Bearer" or credentials.credentials != secret_token:
+    if credentials.scheme != "Bearer" or not hmac.compare_digest(
+        credentials.credentials, secret_token or ""
+    ):
         raise HTTPException(
             status_code=401,
             detail="Unauthorized: Invalid or missing token",

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -86,8 +86,12 @@ def _resolve_agent_secret() -> str:
 def verify_agent_token(
     credentials: HTTPAuthorizationCredentials = Security(security),
 ):
+    import hmac
+
     agent_secret = _resolve_agent_secret()
-    if not agent_secret or credentials.credentials != agent_secret:
+    if not agent_secret or not hmac.compare_digest(
+        credentials.credentials, agent_secret
+    ):
         raise HTTPException(status_code=401, detail="Invalid agent token")
 
 
@@ -543,6 +547,15 @@ async def build_and_restart_deployment(
 
         # Build image if image/ directory exists
         if relative_path:
+            from app.utils import validate_relative_path
+
+            try:
+                validate_relative_path(
+                    automation_service.workspace_repo_dir, relative_path
+                )
+            except ValueError:
+                yield _ndjson(error=f"Invalid relative_path: {relative_path}")
+                return
             source_dir = os.path.join(
                 automation_service.workspace_repo_dir, relative_path
             )

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -49,6 +49,14 @@ async def start_live_dev(
     automation_service: AutomationService = Depends(get_automation_service),
 ):
     """Start a live-dev deployment. Server constructs the deployment ID."""
+    from app.utils import validate_relative_path
+
+    workspace_repo_dir = os.environ.get("BITSWAN_WORKSPACE_REPO_DIR", "/workspace-repo")
+    try:
+        validate_relative_path(workspace_repo_dir, body.relative_path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
     sources = _scan_automations(body.worktree)
     source = next(
         (s for s in sources if s["relative_path"] == body.relative_path), None

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -29,6 +29,7 @@ from app.utils import (
     call_git_command_with_output,
     copy_worktree,
     GitLockContext,
+    safe_zip_extractall,
 )
 from app.async_docker import get_async_docker_client, DockerError
 from app.services.image_service import ImageService
@@ -299,7 +300,7 @@ class AutomationService:
                         tar_ref.extractall(output_dir, filter="data")
                 else:
                     with zipfile.ZipFile(temp_file.name, "r") as zip_ref:
-                        zip_ref.extractall(output_dir)
+                        safe_zip_extractall(zip_ref, output_dir)
 
                 # Verify the checksum using git tree hash algorithm
                 calculated_hash = await calculate_git_tree_hash(output_dir)

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -8,7 +8,7 @@ import zipfile
 import shutil
 from typing import Optional, AsyncGenerator, Dict
 
-from app.utils import calculate_git_tree_hash, save_image
+from app.utils import calculate_git_tree_hash, safe_zip_extractall, save_image
 from app.async_docker import get_async_docker_client, DockerError
 from app.event_broadcaster import event_broadcaster
 
@@ -400,7 +400,7 @@ class ImageService:
                             tar_ref.extractall(temp_dir_path, filter="data")
                     else:
                         with zipfile.ZipFile(temp_file.name, "r") as zip_ref:
-                            zip_ref.extractall(temp_dir_path)
+                            safe_zip_extractall(zip_ref, temp_dir_path)
 
                     # Verify the checksum using git tree hash algorithm
                     calculated_hash = await calculate_git_tree_hash(temp_dir_path)

--- a/app/utils.py
+++ b/app/utils.py
@@ -86,6 +86,39 @@ KNOWN_STAGES = {"live-dev", "dev", "staging", "production"}
 SERVICE_REALMS = {"dev", "staging", "production"}
 
 
+def safe_zip_extractall(zip_ref, target_dir: str) -> None:
+    """Extract a zip file safely, preventing zip slip (path traversal).
+
+    Validates that every extracted file resolves within the target directory.
+    """
+    target_resolved = os.path.realpath(target_dir)
+    for member in zip_ref.namelist():
+        member_path = os.path.realpath(os.path.join(target_dir, member))
+        if (
+            not member_path.startswith(target_resolved + os.sep)
+            and member_path != target_resolved
+        ):
+            raise ValueError(
+                f"Zip slip detected: '{member}' would extract outside '{target_dir}'"
+            )
+    zip_ref.extractall(target_dir)
+
+
+def validate_relative_path(base_dir: str, relative_path: str) -> str:
+    """Validate that a relative path resolves within the base directory.
+
+    Returns the resolved absolute path. Raises ValueError if the path
+    would escape the base directory (e.g., via ../ sequences).
+    """
+    resolved = os.path.realpath(os.path.join(base_dir, relative_path))
+    base_resolved = os.path.realpath(base_dir)
+    if not resolved.startswith(base_resolved + os.sep) and resolved != base_resolved:
+        raise ValueError(
+            f"Path traversal denied: '{relative_path}' resolves outside '{base_dir}'"
+        )
+    return resolved
+
+
 @dataclass
 class AutomationConfig:
     """Unified automation configuration from either automation.toml or pipelines.conf."""


### PR DESCRIPTION
## Summary
Fixes three security vulnerabilities from the security audit:

### 1. Constant-time token comparison
- `app/dependencies.py`: Use `hmac.compare_digest()` instead of `==` for gitops Bearer token
- `app/routes/agent.py`: Same fix for agent token verification
- Prevents timing attacks that could recover API tokens

### 2. Path traversal protection
- Add `validate_relative_path()` utility that checks `os.path.realpath()` stays within the base directory
- Applied to `start-live-dev` endpoint and `build-and-restart` agent route
- Blocks `../` sequences in `relative_path` parameters

### 3. Zip slip fix
- Add `safe_zip_extractall()` that validates every zip member resolves within the target directory before extraction
- Applied to all `zipfile.extractall()` calls in `automation_service.py` and `image_service.py`
- Note: `tarfile.extractall()` already uses `filter="data"` which prevents this for tar archives

## Test plan
- [ ] API authentication still works
- [ ] `start-live-dev` with `../` in relative_path returns 400
- [ ] Asset upload with malicious zip is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)