### PR TITLE
Per-stage network isolation for automations and infra

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -2329,6 +2329,15 @@ fi
                     networks_list = conf["networks"].copy()
                 elif "default-networks" in bs_yaml:
                     networks_list = bs_yaml["default-networks"].copy()
+                elif (
+                    os.environ.get("BITSWAN_STAGE_NETWORKS") == "true"
+                    and self.workspace_name
+                ):
+                    # Use per-stage network for isolation
+                    from app.services.infra_service import stage_for_deployment
+
+                    stage_net = f"{self.workspace_name}-{stage_for_deployment(stage)}"
+                    networks_list = [stage_net]
                 else:
                     networks_list = ["bitswan_network"]
 

--- a/app/services/couchdb_service.py
+++ b/app/services/couchdb_service.py
@@ -53,12 +53,12 @@ class CouchDBService(InfraService):
                     "restart": "unless-stopped",
                     "env_file": [self.secrets_file_path],
                     "volumes": [f"{self.volume_name}:/opt/couchdb/data"],
-                    "networks": ["bitswan_network"],
+                    "networks": [self._get_stage_network()],
                 },
             },
             "volumes": {self.volume_name: None},
             "networks": {
-                "bitswan_network": {"external": True},
+                self._get_stage_network(): {"external": True},
             },
         }
 

--- a/app/services/infra_service.py
+++ b/app/services/infra_service.py
@@ -68,6 +68,16 @@ class InfraService(ABC):
         self.secrets_dir_host = os.path.join(bs_home_host, "secrets")
         self.gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", "")
 
+    def _get_stage_network(self) -> str:
+        """Return the Docker network for this service's stage.
+
+        When stage networks are enabled, returns '{workspace}-{stage}'.
+        Otherwise falls back to 'bitswan_network' for backward compatibility.
+        """
+        if os.environ.get("BITSWAN_STAGE_NETWORKS") == "true" and self.workspace_name:
+            return f"{self.workspace_name}-{self.stage}"
+        return "bitswan_network"
+
     @property
     @abstractmethod
     def service_type(self) -> str:

--- a/app/services/kafka_service.py
+++ b/app/services/kafka_service.py
@@ -147,7 +147,7 @@ class KafkaService(InfraService):
                         "KAFKA_CLUSTERS_0_PROPERTIES_SASL_MECHANISM": "PLAIN",
                     },
                     "env_file": [self.secrets_file_path],
-                    "networks": ["bitswan_network"],
+                    "networks": [self._get_stage_network()],
                 },
                 f"kafka{self.service_suffix}": {
                     "image": self.kafka_image,
@@ -176,12 +176,12 @@ class KafkaService(InfraService):
                     ],
                     "env_file": [self.secrets_file_path],
                     "restart": "unless-stopped",
-                    "networks": ["bitswan_network"],
+                    "networks": [self._get_stage_network()],
                 },
             },
             "volumes": {self.volume_name: None},
             "networks": {
-                "bitswan_network": {"external": True},
+                self._get_stage_network(): {"external": True},
             },
         }
 

--- a/app/services/minio_service.py
+++ b/app/services/minio_service.py
@@ -57,7 +57,7 @@ class MinioService(InfraService):
             "command": "server /data --console-address :9001",
             "env_file": [self.secrets_file_path],
             "volumes": [f"{self.volume_name}-data:/data"],
-            "networks": ["bitswan_network"],
+            "networks": [self._get_stage_network()],
             "labels": {},
         }
 
@@ -73,7 +73,7 @@ class MinioService(InfraService):
             },
             "volumes": {f"{self.volume_name}-data": None},
             "networks": {
-                "bitswan_network": {"external": True},
+                self._get_stage_network(): {"external": True},
             },
         }
 

--- a/app/services/postgres_service.py
+++ b/app/services/postgres_service.py
@@ -72,7 +72,7 @@ class PostgresService(InfraService):
             "volumes": [
                 f"{os.path.join(self.secrets_dir, 'pgadmin-servers.json')}:/pgadmin4/servers.json:ro",
             ],
-            "networks": ["bitswan_network"],
+            "networks": [self._get_stage_network()],
             "labels": {},
         }
 
@@ -92,13 +92,13 @@ class PostgresService(InfraService):
                     "restart": "unless-stopped",
                     "env_file": [self.secrets_file_path],
                     "volumes": [f"{self.volume_name}-data:/var/lib/postgresql/data"],
-                    "networks": ["bitswan_network"],
+                    "networks": [self._get_stage_network()],
                 },
                 f"postgres{self.service_suffix}-pgadmin": pgadmin_entry,
             },
             "volumes": {f"{self.volume_name}-data": None},
             "networks": {
-                "bitswan_network": {"external": True},
+                self._get_stage_network(): {"external": True},
             },
         }
 


### PR DESCRIPTION
## Summary
Gitops side of per-stage Docker network isolation. When `BITSWAN_STAGE_NETWORKS=true` (set by daemon PR #331):

- **Automations**: placed on `{workspace}-{stage}` network (dev/staging/production)
- **live-dev**: maps to dev network via `stage_for_deployment()`
- **Infra services** (postgres, kafka, couchdb, minio): use their stage network
- **Selenium**: unchanged — stays on `bitswan_external_testing`
- **Backward compatible**: without the env var, everything falls back to `bitswan_network`

### Infra service changes
- `infra_service.py`: Add `_get_stage_network()` to base class
- `postgres_service.py`: Use `self._get_stage_network()`
- `kafka_service.py`: Use `self._get_stage_network()`
- `couchdb_service.py`: Use `self._get_stage_network()`
- `minio_service.py`: Use `self._get_stage_network()`

### Automation changes
- `automation_service.py`: Stage-aware network in `generate_docker_compose()`

## Test plan
- [ ] Dev automation + dev postgres on same network → can communicate
- [ ] Dev automation cannot reach production postgres
- [ ] Selenium on external_testing cannot reach any stage network directly
- [ ] Without BITSWAN_STAGE_NETWORKS: all on bitswan_network (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)