### PR TITLE
fix: raise on automation.toml syntax error instead of silently returning None

### DIFF
--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -192,14 +192,6 @@ async def create_worktree(body: CreateWorktreeRequest):
             detail=f"Worktree '{body.branch_name}' already exists",
         )
 
-    # Auto-detect base branch from current HEAD if not provided
-    base_branch = body.base_branch
-    if not base_branch:
-        stdout, _, rc = await call_git_command_with_output(
-            "git", "rev-parse", "--abbrev-ref", "HEAD", cwd=workspace_dir
-        )
-        base_branch = stdout.strip() if rc == 0 and stdout.strip() else "main"
-
     # Ensure worktrees directory exists
     os.makedirs(worktrees_base, exist_ok=True)
 
@@ -233,6 +225,16 @@ async def create_worktree(body: CreateWorktreeRequest):
                 "initial commit",
                 cwd=workspace_dir,
             )
+
+        # Auto-detect base branch AFTER ensuring there is at least one commit.
+        # Doing this before the initial commit would fail (no HEAD) and fall back
+        # to "main", while git may have created the first commit on "master".
+        base_branch = body.base_branch
+        if not base_branch:
+            stdout, _, rc = await call_git_command_with_output(
+                "git", "rev-parse", "--abbrev-ref", "HEAD", cwd=workspace_dir
+            )
+            base_branch = stdout.strip() if rc == 0 and stdout.strip() else "main"
 
         # Create the branch from base
         success = await call_git_command(

--- a/app/utils.py
+++ b/app/utils.py
@@ -146,57 +146,58 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
         return None
     try:
         data = toml.loads(content)
-        deployment = data.get("deployment", {})
-        secrets = data.get("secrets", {})
-        expose_to_section = data.get("expose_to", {})
+    except toml.TomlDecodeError as e:
+        raise ValueError(f"Syntax error in automation.toml: {e}") from e
 
-        # Parse allowed_domains as a list (for CORS in Keycloak client)
-        allowed_domains = deployment.get("allowed_domains")
-        if isinstance(allowed_domains, list):
-            allowed_domains = [
-                str(d).strip() for d in allowed_domains if str(d).strip()
-            ]
-        else:
-            allowed_domains = None
+    deployment = data.get("deployment", {})
+    secrets = data.get("secrets", {})
+    expose_to_section = data.get("expose_to", {})
 
-        # Parse [services.*] sections
-        services_data = data.get("services", {})
-        services = None
-        if services_data and isinstance(services_data, dict):
-            services = {}
-            for svc_type, svc_conf in services_data.items():
-                if not isinstance(svc_conf, dict):
-                    continue
-                services[svc_type] = ServiceDependency(
-                    enabled=svc_conf.get("enabled", True),
-                )
+    # Parse allowed_domains as a list (for CORS in Keycloak client)
+    allowed_domains = deployment.get("allowed_domains")
+    if isinstance(allowed_domains, list):
+        allowed_domains = [
+            str(d).strip() for d in allowed_domains if str(d).strip()
+        ]
+    else:
+        allowed_domains = None
 
-        return AutomationConfig(
-            id=deployment.get("id"),
-            auth=deployment.get("auth", False),
-            image=deployment.get(
-                "image", "bitswan/pipeline-runtime-environment:latest"
-            ),
-            expose=deployment.get("expose", False),
-            port=deployment.get("port", 8080),
-            config_format="toml",
-            mount_path="/app/",
-            live_dev_groups=_parse_string_or_list(secrets.get("live-dev")),
-            dev_groups=_parse_string_or_list(secrets.get("dev")),
-            staging_groups=_parse_string_or_list(secrets.get("staging")),
-            production_groups=_parse_string_or_list(secrets.get("production")),
-            # Per-stage expose_to from [expose_to] section
-            dev_expose_to=_parse_string_or_list(expose_to_section.get("dev")),
-            staging_expose_to=_parse_string_or_list(expose_to_section.get("staging")),
-            production_expose_to=_parse_string_or_list(
-                expose_to_section.get("production")
-            ),
-            allowed_domains=allowed_domains,
-            services=services,
-            external_testing_network=deployment.get("external-testing-network", False),
-        )
-    except Exception:
-        return None
+    # Parse [services.*] sections
+    services_data = data.get("services", {})
+    services = None
+    if services_data and isinstance(services_data, dict):
+        services = {}
+        for svc_type, svc_conf in services_data.items():
+            if not isinstance(svc_conf, dict):
+                continue
+            services[svc_type] = ServiceDependency(
+                enabled=svc_conf.get("enabled", True),
+            )
+
+    return AutomationConfig(
+        id=deployment.get("id"),
+        auth=deployment.get("auth", False),
+        image=deployment.get(
+            "image", "bitswan/pipeline-runtime-environment:latest"
+        ),
+        expose=deployment.get("expose", False),
+        port=deployment.get("port", 8080),
+        config_format="toml",
+        mount_path="/app/",
+        live_dev_groups=_parse_string_or_list(secrets.get("live-dev")),
+        dev_groups=_parse_string_or_list(secrets.get("dev")),
+        staging_groups=_parse_string_or_list(secrets.get("staging")),
+        production_groups=_parse_string_or_list(secrets.get("production")),
+        # Per-stage expose_to from [expose_to] section
+        dev_expose_to=_parse_string_or_list(expose_to_section.get("dev")),
+        staging_expose_to=_parse_string_or_list(expose_to_section.get("staging")),
+        production_expose_to=_parse_string_or_list(
+            expose_to_section.get("production")
+        ),
+        allowed_domains=allowed_domains,
+        services=services,
+        external_testing_network=deployment.get("external-testing-network", False),
+    )
 
 
 def read_automation_toml(source_dir: str) -> AutomationConfig | None:

--- a/app/utils.py
+++ b/app/utils.py
@@ -156,9 +156,7 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
     # Parse allowed_domains as a list (for CORS in Keycloak client)
     allowed_domains = deployment.get("allowed_domains")
     if isinstance(allowed_domains, list):
-        allowed_domains = [
-            str(d).strip() for d in allowed_domains if str(d).strip()
-        ]
+        allowed_domains = [str(d).strip() for d in allowed_domains if str(d).strip()]
     else:
         allowed_domains = None
 
@@ -177,9 +175,7 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
     return AutomationConfig(
         id=deployment.get("id"),
         auth=deployment.get("auth", False),
-        image=deployment.get(
-            "image", "bitswan/pipeline-runtime-environment:latest"
-        ),
+        image=deployment.get("image", "bitswan/pipeline-runtime-environment:latest"),
         expose=deployment.get("expose", False),
         port=deployment.get("port", 8080),
         config_format="toml",
@@ -191,9 +187,7 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
         # Per-stage expose_to from [expose_to] section
         dev_expose_to=_parse_string_or_list(expose_to_section.get("dev")),
         staging_expose_to=_parse_string_or_list(expose_to_section.get("staging")),
-        production_expose_to=_parse_string_or_list(
-            expose_to_section.get("production")
-        ),
+        production_expose_to=_parse_string_or_list(expose_to_section.get("production")),
         allowed_domains=allowed_domains,
         services=services,
         external_testing_network=deployment.get("external-testing-network", False),


### PR DESCRIPTION
## Summary
- `parse_automation_toml` previously caught all exceptions with `except Exception: return None`, silently swallowing `toml.TomlDecodeError` and causing deployments to proceed with incorrect config
- Now separates TOML parsing from config processing: `TomlDecodeError` is re-raised as `ValueError` with message `"Syntax error in automation.toml: <details>"`
- This allows the deploy endpoint to propagate the error back to the client via SSE `deploy_progress` events with `FAILED` status

## Test plan
- [ ] Deploy an automation with a syntax error in `automation.toml` — should now receive an error message instead of silent failure
- [ ] Deploy an automation with a valid `automation.toml` — should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)