### PR TITLE
fix: improve async lifecycle management

### DIFF
--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -229,10 +229,19 @@ async def lifespan(app: FastAPI):
         scheduler.start()
 
     # Warm the history cache in the background so first requests are fast
-    asyncio.create_task(get_automation_service().warm_history_cache())
+    _cache_task = asyncio.create_task(get_automation_service().warm_history_cache())
+    _cache_task.add_done_callback(
+        lambda t: (
+            logger.warning("warm_history_cache failed: %s", t.exception())
+            if not t.cancelled() and t.exception()
+            else None
+        )
+    )
 
     # Start Docker event watcher for SSE push updates
     watcher_task = asyncio.create_task(_docker_event_watcher())
+
+    docker_client = get_async_docker_client()
 
     try:
         yield
@@ -244,6 +253,10 @@ async def lifespan(app: FastAPI):
                 await watcher_task
             except asyncio.CancelledError:
                 pass
+
+        # Explicitly close the Docker client session so aiohttp doesn't report
+        # "Unclosed client session" warnings during interpreter shutdown
+        await docker_client.close()
 
         if observer:
             observer.stop()

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -24,6 +24,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agent", tags=["agent"])
 
+# Strong references to background deploy tasks — prevents GC before completion
+_bg_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_bg(coro) -> asyncio.Task:
+    t = asyncio.create_task(coro)
+    _bg_tasks.add(t)
+    t.add_done_callback(_bg_tasks.discard)
+    return t
+
+
 security = HTTPBearer()
 
 # Pattern for valid worktree live-dev deployment IDs
@@ -322,7 +333,7 @@ async def start_agent_deployment(
                 task.task_id, error=str(exc), message="Deployment failed"
             )
 
-    asyncio.create_task(_run_deploy())
+    _spawn_bg(_run_deploy())
 
     workspace_name = os.environ.get("BITSWAN_WORKSPACE_NAME", "workspace-local")
     gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", "")

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -29,6 +29,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/automations", tags=["automations"])
 
+# Strong references to background deploy tasks — prevents GC before completion
+_bg_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_bg(coro) -> asyncio.Task:
+    t = asyncio.create_task(coro)
+    _bg_tasks.add(t)
+    t.add_done_callback(_bg_tasks.discard)
+    return t
+
 
 @router.get("/")
 async def get_automations(
@@ -84,7 +94,7 @@ async def start_live_dev(
         context=source["context"],
     )
 
-    asyncio.create_task(
+    _spawn_bg(
         _run_deploy_with_progress(
             task.task_id, deployment_id, automation_service, deploy_kwargs
         )
@@ -257,7 +267,7 @@ async def deploy_automation(
     )
 
     # Spawn background task — returns 202 immediately
-    asyncio.create_task(
+    _spawn_bg(
         _run_deploy_with_progress(
             task.task_id, deployment_id, automation_service, deploy_kwargs
         )


### PR DESCRIPTION
## Summary

- **Close Docker client session on shutdown** — the `AsyncDockerClient` singleton holds a long-lived `aiohttp.ClientSession` / `UnixConnector` (used for the streaming `/events` watcher). Previously `close()` was never called, so Python's GC reported `Unclosed client session` / `Unclosed connector` warnings at interpreter shutdown. Fixed by adding `await docker_client.close()` to the lifespan `finally` block.

- **Surface `warm_history_cache` failures** — the startup background task was fire-and-forget with no error visibility. Now the returned `Task` is stored and a `done_callback` logs any exception via the app logger.

- **Hold strong references to background deploy tasks** — bare `asyncio.create_task()` calls in `routes/automations.py` and `routes/agent.py` dropped the task reference immediately. While the event loop keeps pending tasks alive, any unhandled exception would be silently discarded by the GC. Replaced with a `_spawn_bg()` helper that stores tasks in a module-level `set` and removes them via `add_done_callback` on completion.

## Test plan
- [ ] Restart the gitops container and confirm no `Unclosed client session` warnings in the logs
- [ ] Deliberately break `warm_history_cache` (e.g. corrupt bitswan.yaml) and confirm the failure is logged
- [ ] Deploy an automation and confirm the background task completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)