### PR TITLE
fix: permission error on automation redeploy

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -417,8 +417,30 @@ class AutomationService:
         checksum: Pre-calculated git tree hash that will be verified.
         """
         output_dir = os.path.join(self.gitops_dir, checksum)
-        # Clean any stale files from a previous extraction attempt
         if os.path.exists(output_dir):
+            # If the tree is already in git, the asset was extracted and committed
+            # on a previous request — treat re-upload as a no-op. The automation
+            # container may have written build artifacts (dist/, node_modules/)
+            # into output_dir as root, which would make rmtree fail, but we don't
+            # need to clean: the asset is already stored.
+            # Use "HEAD:<path>" rather than bare "<checksum>" because our
+            # checksum is a normalized tree hash (all files forced to 100644),
+            # which differs from git's actual tree SHA when any file is +x
+            # (e.g. entrypoint.sh → 100755). The path-in-HEAD check is
+            # mode-agnostic.
+            _, _, rc = await call_git_command_with_output(
+                "git", "cat-file", "-e", f"HEAD:{checksum}", cwd=self.gitops_dir
+            )
+            if rc == 0:
+                logger.info(
+                    "Asset %s already committed; skipping re-extraction", checksum
+                )
+                return {
+                    "message": "Asset already uploaded",
+                    "output_directory": output_dir,
+                    "checksum": checksum,
+                }
+            # Stale files from a failed previous extraction — clean them.
             shutil.rmtree(output_dir)
         os.makedirs(output_dir)
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     

  When re-uploading an unchanged asset (same checksum), the endpoint returned 500                                                                                                                                
  with `PermissionError: [Errno 13] Permission denied: 'bitswan.svg'`.
                                                                                                                                                                                                                 
  Root cause: automation containers bind-mount their asset dir                                                                                                                                                   
  (`/gitops/gitops/<checksum>/`) writable and run as root. During deploy they                                                                                                                                    
  produce build artifacts (`dist/`, `node_modules/`, `package.json`) that end up                                                                                                                                 
  owned by uid 0 on the host. On the next upload of the same checksum, the                                                                                                                                       
  gitops daemon (uid 1000) runs `shutil.rmtree(output_dir)` to clean before                                                                                                                                      
  re-extracting, which fails because user1000 can't unlink root-owned files.                                                                                                                                     
                                                                                                                                                                                                                 
  Fix: treat re-upload of an already-committed checksum as an idempotent no-op.                                                                                                                                  
  The checksum uniquely identifies the source tree, so if `HEAD:<checksum>`                                                                                                                                      
  resolves in the gitops git repo, extraction has already succeeded — we don't                                                                                                                                   
  need to touch the directory. The stray root-owned build artifacts are                                                                                                                                          
  harmless; the next deploy's container will overwrite them.                                                                                                                                                     
                                                                                                                                                                                                                 
  ## Why `HEAD:<checksum>` instead of `<checksum>`                                                                                                                                                               
                                                                                                                                                                                                                 
  The app's tree hash normalizes every file to mode `100644`, but git stores                                                                                                                                     
  executable files as `100755` (e.g. `entrypoint.sh`). That makes the app's
  checksum ≠ git's actual tree SHA, so `git cat-file -e <checksum>` misses even                                                                                                                                  
  when the path is committed. `HEAD:<checksum>` resolves by path, which is                                                                                                                                       
  mode-agnostic.