### PR TITLE
fix: detect container name conflicts before deploy, return 409

### DIFF
--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -24,6 +24,7 @@ from app.event_broadcaster import event_broadcaster
 from app.routes.agent import _scan_automations
 from app.services.automation_service import AutomationService, make_hostname_label
 from app.dependencies import get_automation_service
+from app.async_docker import get_async_docker_client, DockerError
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,41 @@ async def start_live_dev(
             detail=f"Deployment {deployment_id} is already in progress",
         )
 
+    workspace_name = os.environ.get("BITSWAN_WORKSPACE_NAME", "workspace-local")
+
+    # Pre-flight: check for container name conflicts before reserving a deploy slot.
+    # Must run here in the route handler (not inside the background task) so we can
+    # return HTTP 409; exceptions raised in background tasks are not propagated to callers.
+    compose_service_name = make_hostname_label(
+        workspace_name,
+        source["automation_name"],
+        source["context"],
+        "live-dev",
+    )
+    docker_client = get_async_docker_client()
+    try:
+        existing = await docker_client.get_container(compose_service_name)
+        existing_dep_id = (
+            existing.get("Config", {}).get("Labels", {}).get("gitops.deployment_id", "")
+        )
+        if existing_dep_id == deployment_id:
+            # Scenario A: our container — remove it so compose can recreate it cleanly.
+            await docker_client.remove_container(compose_service_name, force=True)
+        else:
+            # Scenario B: foreign container — reject with 409 so the user can clean up.
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A container named '{compose_service_name}' already exists "
+                    f"but is not managed by this GitOps instance "
+                    f"(deployment_id '{existing_dep_id or 'none'}'). "
+                    f"Remove it manually and retry."
+                ),
+            )
+    except DockerError as e:
+        if e.status_code != 404:
+            raise  # unexpected Docker API error — propagate
+
     task = await deploy_manager.create_task(deployment_id)
     if task is None:
         raise HTTPException(
@@ -100,7 +136,6 @@ async def start_live_dev(
         )
     )
 
-    workspace_name = os.environ.get("BITSWAN_WORKSPACE_NAME", "workspace-local")
     gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", "")
     url = ""
     if gitops_domain:

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1275,40 +1275,26 @@ fi
             dep_conf.get("stage", "production") or "production",
         )
 
-        # Pre-flight: check whether a container with this name already exists.
-        # Two scenarios:
-        #   A) It's ours (correct gitops.deployment_id label) → remove it so
-        #      compose can recreate it cleanly (redeployment / update).
-        #   B) It's foreign (no matching label) → reject with a clear 409 so
-        #      the user knows to clean it up manually instead of seeing a
-        #      cryptic "Error deploying services".
+        # Scenario A race-condition guard: if a container reappeared between the
+        # route-handler pre-flight and now, remove it so compose can recreate it.
+        # Foreign-container conflicts (Scenario B) are caught in the route handler
+        # before the task is created, so we only need to handle our own containers here.
         docker_client = get_async_docker_client()
         try:
             existing = await docker_client.get_container(compose_service_name)
-            existing_labels = existing.get("Config", {}).get("Labels", {})
-            existing_dep_id = existing_labels.get("gitops.deployment_id", "")
+            existing_dep_id = (
+                existing.get("Config", {}).get("Labels", {}).get("gitops.deployment_id", "")
+            )
             if existing_dep_id == deployment_id:
-                # Scenario A: our container — remove so compose recreates it.
                 logger.info(
-                    "Removing existing container '%s' for redeployment of '%s'",
+                    "Race-condition guard: removing container '%s' before redeployment of '%s'",
                     compose_service_name,
                     deployment_id,
                 )
                 await docker_client.remove_container(compose_service_name, force=True)
-            else:
-                # Scenario B: foreign container occupying our name.
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"A container named '{compose_service_name}' already exists "
-                        f"but is not managed by this GitOps instance "
-                        f"(deployment_id '{existing_dep_id or 'none'}'). "
-                        f"Remove it manually and retry."
-                    ),
-                )
         except DockerError as e:
             if e.status_code != 404:
-                raise  # unexpected Docker API error — propagate
+                raise
 
         # deploy the automation and its infra services
         await _report("docker_compose_up", "Starting containers...")

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1275,6 +1275,41 @@ fi
             dep_conf.get("stage", "production") or "production",
         )
 
+        # Pre-flight: check whether a container with this name already exists.
+        # Two scenarios:
+        #   A) It's ours (correct gitops.deployment_id label) → remove it so
+        #      compose can recreate it cleanly (redeployment / update).
+        #   B) It's foreign (no matching label) → reject with a clear 409 so
+        #      the user knows to clean it up manually instead of seeing a
+        #      cryptic "Error deploying services".
+        docker_client = get_async_docker_client()
+        try:
+            existing = await docker_client.get_container(compose_service_name)
+            existing_labels = existing.get("Config", {}).get("Labels", {})
+            existing_dep_id = existing_labels.get("gitops.deployment_id", "")
+            if existing_dep_id == deployment_id:
+                # Scenario A: our container — remove so compose recreates it.
+                logger.info(
+                    "Removing existing container '%s' for redeployment of '%s'",
+                    compose_service_name,
+                    deployment_id,
+                )
+                await docker_client.remove_container(compose_service_name, force=True)
+            else:
+                # Scenario B: foreign container occupying our name.
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"A container named '{compose_service_name}' already exists "
+                        f"but is not managed by this GitOps instance "
+                        f"(deployment_id '{existing_dep_id or 'none'}'). "
+                        f"Remove it manually and retry."
+                    ),
+                )
+        except DockerError as e:
+            if e.status_code != 404:
+                raise  # unexpected Docker API error — propagate
+
         # deploy the automation and its infra services
         await _report("docker_compose_up", "Starting containers...")
         deployment_result = await docker_compose_up(
@@ -1294,9 +1329,24 @@ fi
 
         for result in deployment_result.values():
             if result["return_code"] != 0:
+                stderr = result.get("stderr", "")
+                # Surface Docker name-conflict errors as a 409 rather than a
+                # generic 500 — this handles races where the pre-flight check
+                # passed but a container appeared between check and compose up.
+                if "already in use by container" in stderr or (
+                    "Conflict" in stderr and "container name" in stderr.lower()
+                ):
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Deployment failed: a container named "
+                            f"'{compose_service_name}' already exists. "
+                            f"Docker error: {stderr.strip()}"
+                        ),
+                    )
                 raise HTTPException(
                     status_code=500,
-                    detail=f"Error deploying services: \ndocker-compose:\n {dc_yaml}\n\nstdout:\n {result['stdout']}\nstderr:\n{result['stderr']}\n",
+                    detail=f"Error deploying services:\nstdout:\n{result['stdout']}\nstderr:\n{stderr}\n",
                 )
 
         await _report("installing_certs", "Installing certificates...")

--- a/scripts/test_deployment_conflict.sh
+++ b/scripts/test_deployment_conflict.sh
@@ -3,136 +3,189 @@
 #
 # Validates the two conflict-detection scenarios for deployment name collisions.
 #
-# Scenario A: redeploying an automation we own — should succeed (container is
-#             removed and recreated, no 409).
-# Scenario B: a foreign container occupies the target name — should return 409
-#             with a clear message.
+# Scenario A: redeploying an automation we own — should succeed (202, no 409).
+#             The route handler removes the existing container so compose can
+#             recreate it cleanly.
+# Scenario B: a foreign container (no gitops label) occupies the target name —
+#             should return 409 with a message containing 'already exists'.
 #
 # Usage:
 #   ./scripts/test_deployment_conflict.sh [GITOPS_URL] [GITOPS_SECRET] [WORKSPACE]
 #
-# Defaults to the test1 workspace running locally.
+# GITOPS_URL defaults to auto-detecting the running gitops container's Docker IP
+# when localhost:8079 is not published to the host (normal in the bitswan stack).
 
 set -euo pipefail
 
-GITOPS_URL="${1:-http://localhost:8079}"
-GITOPS_SECRET="${2:-${BITSWAN_GITOPS_SECRET:-}}"
 WORKSPACE="${3:-test1}"
 
+# ── URL auto-detection ────────────────────────────────────────────────────────
+# The gitops container may not publish 8079 to the host (only internal Docker
+# networking). Find it by container name pattern and use its internal IP.
+_detect_url() {
+    if curl -sf --connect-timeout 2 "http://localhost:8079/" -o /dev/null 2>/dev/null; then
+        echo "http://localhost:8079"
+        return
+    fi
+    local container
+    container=$(docker ps --filter "name=${WORKSPACE}.*gitops" --format "{{.Names}}" 2>/dev/null | head -1)
+    if [[ -n "$container" ]]; then
+        local ip
+        ip=$(docker inspect "$container" \
+            --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{break}}{{end}}' 2>/dev/null)
+        if [[ -n "$ip" ]]; then
+            echo "http://${ip}:8079"
+            return
+        fi
+    fi
+    echo "http://localhost:8079"
+}
+
+GITOPS_URL="${1:-$(_detect_url)}"
+
+# ── Secret ────────────────────────────────────────────────────────────────────
+GITOPS_SECRET="${2:-${BITSWAN_GITOPS_SECRET:-}}"
 if [[ -z "$GITOPS_SECRET" ]]; then
-    echo "ERROR: GITOPS_SECRET not set. Pass it as \$2 or export BITSWAN_GITOPS_SECRET."
+    # Last resort: read from the running gitops container's environment
+    _container=$(docker ps --filter "name=${WORKSPACE}.*gitops" --format "{{.Names}}" 2>/dev/null | head -1)
+    if [[ -n "$_container" ]]; then
+        GITOPS_SECRET=$(docker exec "$_container" env 2>/dev/null \
+            | grep '^BITSWAN_GITOPS_SECRET=' | cut -d= -f2 || true)
+    fi
+fi
+if [[ -z "$GITOPS_SECRET" ]]; then
+    echo "ERROR: GITOPS_SECRET not set. Pass as \$2 or export BITSWAN_GITOPS_SECRET."
     exit 1
 fi
 
 AUTH_HEADER="Authorization: Bearer $GITOPS_SECRET"
+echo "Gitops URL : $GITOPS_URL"
+echo "Workspace  : $WORKSPACE"
 
-# Find a real automation source in the workspace to use as the test subject.
-# We pick the first one returned by the agent deployments endpoint.
+# ── curl helper: one round-trip captures both body and status ─────────────────
+# Sets global RESP_BODY and RESP_STATUS.
+http_post() {
+    local url="$1" data="$2"
+    local tmp
+    tmp=$(mktemp)
+    RESP_STATUS=$(curl -s -o "$tmp" -w "%{http_code}" -X POST "$url" \
+        -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+        -d "$data" 2>/dev/null) || RESP_STATUS="000"
+    RESP_BODY=$(cat "$tmp")
+    rm -f "$tmp"
+}
+
+# ── Find automation ───────────────────────────────────────────────────────────
 echo ""
 echo "=== Fetching available automations in workspace '$WORKSPACE' ==="
 SOURCES=$(curl -sf "$GITOPS_URL/agent/deployments?worktree=" \
     -H "$AUTH_HEADER" 2>/dev/null || echo "[]")
 
 if [[ "$SOURCES" == "[]" || -z "$SOURCES" ]]; then
-    echo "No automations found via /agent/deployments — scanning workspace dir instead."
+    echo "No automations via /agent/deployments — scanning workspace dir."
     WORKSPACE_DIR="${BITSWAN_WORKSPACE_REPO_DIR:-/home/john/.config/bitswan/workspaces/$WORKSPACE/workspace}"
     TOML_FILE=$(find "$WORKSPACE_DIR" -name "automation.toml" -not -path "*/worktrees/*" | head -1)
     if [[ -z "$TOML_FILE" ]]; then
-        echo "ERROR: No automation.toml found in $WORKSPACE_DIR. Cannot run test."
+        echo "ERROR: No automation.toml found in $WORKSPACE_DIR"
         exit 1
     fi
     REL_PATH=$(dirname "$(realpath --relative-to="$WORKSPACE_DIR" "$TOML_FILE")")
-    echo "Using automation at relative path: $REL_PATH"
+    DEP_ID=""
+    echo "Using automation at: $REL_PATH"
 else
-    REL_PATH=$(echo "$SOURCES" | python3 -c "import sys,json; s=json.load(sys.stdin); print(s[0]['relative_path'])" 2>/dev/null || echo "")
-    if [[ -z "$REL_PATH" ]]; then
-        echo "ERROR: Could not parse relative_path from sources."
-        exit 1
-    fi
-    echo "Using automation: $REL_PATH"
+    REL_PATH=$(echo "$SOURCES" | python3 -c \
+        "import sys,json; s=json.load(sys.stdin); print(s[0]['relative_path'])" 2>/dev/null || echo "")
+    DEP_ID=$(echo "$SOURCES" | python3 -c \
+        "import sys,json; s=json.load(sys.stdin); print(s[0].get('deployment_id',''))" 2>/dev/null || echo "")
+    [[ -z "$REL_PATH" ]] && { echo "ERROR: could not parse relative_path"; exit 1; }
+    echo "Using automation: $REL_PATH  (deployment_id: $DEP_ID)"
 fi
+
+DEPLOY_BODY=$(python3 -c "import json; print(json.dumps({'relative_path': '$REL_PATH'}))")
 
 PASS=0
 FAIL=0
 
 check() {
-    local desc="$1" expected_status="$2" actual_status="$3" body="$4"
-    if [[ "$actual_status" == "$expected_status" ]]; then
-        echo "  PASS [$actual_status] $desc"
+    local desc="$1" expected="$2" actual="$3" body="$4"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS [$actual] $desc"
         ((PASS++)) || true
     else
-        echo "  FAIL [$actual_status != $expected_status] $desc"
+        echo "  FAIL [$actual != $expected] $desc"
         echo "       body: $body"
         ((FAIL++)) || true
     fi
 }
 
-# ── Scenario A: redeployment (same deployment_id, our container) ──────────────
-echo ""
-echo "=== Scenario A: redeployment of our own automation ==="
-echo "    Deploying '$REL_PATH' twice — second deploy should succeed (200/202)."
-
-deploy_body() {
-    python3 -c "import json; print(json.dumps({'relative_path': '$REL_PATH'}))"
+# ── wait for a container with the given label to appear ───────────────────────
+wait_for_label() {
+    local label="$1" timeout="${2:-25}"
+    local i=0
+    while (( i < timeout )); do
+        docker ps --filter "label=$label" --format "{{.Names}}" 2>/dev/null | grep -q . && return 0
+        sleep 1; ((i++))
+    done
+    return 1
 }
 
-RESP1=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
-    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-    -d "$(deploy_body)" 2>/dev/null || echo "000")
-echo "  First deploy: HTTP $RESP1"
+# ── Scenario A ────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario A: redeployment of our own automation ==="
+echo "    Two deploys of '$REL_PATH' — second should succeed (202)."
 
-# Give the first deploy a moment to register the container name.
-sleep 3
+http_post "$GITOPS_URL/automations/start-live-dev" "$DEPLOY_BODY"
+echo "  First deploy: HTTP $RESP_STATUS  body: $RESP_BODY"
 
-RESP2_BODY=$(curl -s -X POST "$GITOPS_URL/automations/start-live-dev" \
-    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-    -d "$(deploy_body)" 2>/dev/null || echo "{}")
-RESP2=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
-    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-    -d "$(deploy_body)" 2>/dev/null || echo "000")
+# Wait for the first deploy's container to appear before firing the second.
+if [[ -n "$DEP_ID" ]]; then
+    echo "    Waiting for container (label gitops.deployment_id=$DEP_ID)..."
+    wait_for_label "gitops.deployment_id=$DEP_ID" 25 || echo "    (container not seen — continuing anyway)"
+else
+    sleep 6
+fi
 
-check "Second deploy of same automation succeeds (no 409)" "202" "$RESP2" "$RESP2_BODY"
+http_post "$GITOPS_URL/automations/start-live-dev" "$DEPLOY_BODY"
+check "Second deploy of same automation succeeds (no 409)" "202" "$RESP_STATUS" "$RESP_BODY"
 
-# ── Scenario B: foreign container occupying the name ─────────────────────────
+# ── Scenario B ────────────────────────────────────────────────────────────────
 echo ""
 echo "=== Scenario B: foreign container blocking the deployment name ==="
 
-# Derive the container name gitops would use.
-# Format: {workspace}-{sanitized_source_name}-{stage}
-SOURCE_NAME=$(basename "$REL_PATH")
-SANITIZED=$(echo "$SOURCE_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/^-//;s/-$//')
-CONTAINER_NAME="${WORKSPACE}-${SANITIZED}-live-dev"
-echo "    Target container name: $CONTAINER_NAME"
+# Get the actual container name via the gitops.deployment_id label — this accounts
+# for the 4-char context hash that the simplified name derivation misses.
+CONTAINER_NAME=""
+if [[ -n "$DEP_ID" ]]; then
+    CONTAINER_NAME=$(docker ps -a --filter "label=gitops.deployment_id=$DEP_ID" \
+        --format "{{.Names}}" 2>/dev/null | head -1)
+fi
+if [[ -z "$CONTAINER_NAME" ]]; then
+    # Fallback: sanitised name without hash (no context / simple automation)
+    SANITIZED=$(basename "$REL_PATH" \
+        | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g;s/^-//;s/-$//')
+    CONTAINER_NAME="${WORKSPACE}-${SANITIZED}-live-dev"
+    echo "  (label lookup failed — using derived name)"
+fi
+echo "  Target container name: $CONTAINER_NAME"
 
-# Create a foreign container with that name (busybox, keeps running briefly).
-echo "    Spawning foreign container '$CONTAINER_NAME'..."
-docker run -d --name "$CONTAINER_NAME" busybox sh -c "sleep 30" >/dev/null 2>&1 || {
-    echo "    (container already exists — removing and re-creating)"
-    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1
-    docker run -d --name "$CONTAINER_NAME" busybox sh -c "sleep 30" >/dev/null 2>&1
-}
+# Remove the real container (if any) and spawn a foreign one without gitops labels.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+echo "  Spawning foreign container '$CONTAINER_NAME'..."
+docker run -d --name "$CONTAINER_NAME" busybox sh -c "sleep 60" >/dev/null 2>&1
 
-RESP3_BODY=$(curl -s -X POST "$GITOPS_URL/automations/start-live-dev" \
-    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-    -d "$(deploy_body)" 2>/dev/null || echo "{}")
-RESP3=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
-    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-    -d "$(deploy_body)" 2>/dev/null || echo "000")
+http_post "$GITOPS_URL/automations/start-live-dev" "$DEPLOY_BODY"
+check "Foreign container → 409 conflict" "409" "$RESP_STATUS" "$RESP_BODY"
 
-check "Foreign container → 409 conflict" "409" "$RESP3" "$RESP3_BODY"
-
-# Check the message is useful.
-if echo "$RESP3_BODY" | grep -q "already exists"; then
+if echo "$RESP_BODY" | grep -q "already exists"; then
     echo "  PASS error message contains 'already exists'"
     ((PASS++)) || true
 else
-    echo "  FAIL error message missing 'already exists': $RESP3_BODY"
+    echo "  FAIL error message missing 'already exists': $RESP_BODY"
     ((FAIL++)) || true
 fi
 
-# Clean up the foreign container.
 docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-echo "    Foreign container removed."
+echo "  Foreign container removed."
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/test_deployment_conflict.sh
+++ b/scripts/test_deployment_conflict.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_deployment_conflict.sh
+#
+# Validates the two conflict-detection scenarios for deployment name collisions.
+#
+# Scenario A: redeploying an automation we own — should succeed (container is
+#             removed and recreated, no 409).
+# Scenario B: a foreign container occupies the target name — should return 409
+#             with a clear message.
+#
+# Usage:
+#   ./scripts/test_deployment_conflict.sh [GITOPS_URL] [GITOPS_SECRET] [WORKSPACE]
+#
+# Defaults to the test1 workspace running locally.
+
+set -euo pipefail
+
+GITOPS_URL="${1:-http://localhost:8079}"
+GITOPS_SECRET="${2:-${BITSWAN_GITOPS_SECRET:-}}"
+WORKSPACE="${3:-test1}"
+
+if [[ -z "$GITOPS_SECRET" ]]; then
+    echo "ERROR: GITOPS_SECRET not set. Pass it as \$2 or export BITSWAN_GITOPS_SECRET."
+    exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer $GITOPS_SECRET"
+
+# Find a real automation source in the workspace to use as the test subject.
+# We pick the first one returned by the agent deployments endpoint.
+echo ""
+echo "=== Fetching available automations in workspace '$WORKSPACE' ==="
+SOURCES=$(curl -sf "$GITOPS_URL/agent/deployments?worktree=" \
+    -H "$AUTH_HEADER" 2>/dev/null || echo "[]")
+
+if [[ "$SOURCES" == "[]" || -z "$SOURCES" ]]; then
+    echo "No automations found via /agent/deployments — scanning workspace dir instead."
+    WORKSPACE_DIR="${BITSWAN_WORKSPACE_REPO_DIR:-/home/john/.config/bitswan/workspaces/$WORKSPACE/workspace}"
+    TOML_FILE=$(find "$WORKSPACE_DIR" -name "automation.toml" -not -path "*/worktrees/*" | head -1)
+    if [[ -z "$TOML_FILE" ]]; then
+        echo "ERROR: No automation.toml found in $WORKSPACE_DIR. Cannot run test."
+        exit 1
+    fi
+    REL_PATH=$(dirname "$(realpath --relative-to="$WORKSPACE_DIR" "$TOML_FILE")")
+    echo "Using automation at relative path: $REL_PATH"
+else
+    REL_PATH=$(echo "$SOURCES" | python3 -c "import sys,json; s=json.load(sys.stdin); print(s[0]['relative_path'])" 2>/dev/null || echo "")
+    if [[ -z "$REL_PATH" ]]; then
+        echo "ERROR: Could not parse relative_path from sources."
+        exit 1
+    fi
+    echo "Using automation: $REL_PATH"
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1" expected_status="$2" actual_status="$3" body="$4"
+    if [[ "$actual_status" == "$expected_status" ]]; then
+        echo "  PASS [$actual_status] $desc"
+        ((PASS++)) || true
+    else
+        echo "  FAIL [$actual_status != $expected_status] $desc"
+        echo "       body: $body"
+        ((FAIL++)) || true
+    fi
+}
+
+# ── Scenario A: redeployment (same deployment_id, our container) ──────────────
+echo ""
+echo "=== Scenario A: redeployment of our own automation ==="
+echo "    Deploying '$REL_PATH' twice — second deploy should succeed (200/202)."
+
+deploy_body() {
+    python3 -c "import json; print(json.dumps({'relative_path': '$REL_PATH'}))"
+}
+
+RESP1=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$(deploy_body)" 2>/dev/null || echo "000")
+echo "  First deploy: HTTP $RESP1"
+
+# Give the first deploy a moment to register the container name.
+sleep 3
+
+RESP2_BODY=$(curl -s -X POST "$GITOPS_URL/automations/start-live-dev" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$(deploy_body)" 2>/dev/null || echo "{}")
+RESP2=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$(deploy_body)" 2>/dev/null || echo "000")
+
+check "Second deploy of same automation succeeds (no 409)" "202" "$RESP2" "$RESP2_BODY"
+
+# ── Scenario B: foreign container occupying the name ─────────────────────────
+echo ""
+echo "=== Scenario B: foreign container blocking the deployment name ==="
+
+# Derive the container name gitops would use.
+# Format: {workspace}-{sanitized_source_name}-{stage}
+SOURCE_NAME=$(basename "$REL_PATH")
+SANITIZED=$(echo "$SOURCE_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/^-//;s/-$//')
+CONTAINER_NAME="${WORKSPACE}-${SANITIZED}-live-dev"
+echo "    Target container name: $CONTAINER_NAME"
+
+# Create a foreign container with that name (busybox, keeps running briefly).
+echo "    Spawning foreign container '$CONTAINER_NAME'..."
+docker run -d --name "$CONTAINER_NAME" busybox sh -c "sleep 30" >/dev/null 2>&1 || {
+    echo "    (container already exists — removing and re-creating)"
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1
+    docker run -d --name "$CONTAINER_NAME" busybox sh -c "sleep 30" >/dev/null 2>&1
+}
+
+RESP3_BODY=$(curl -s -X POST "$GITOPS_URL/automations/start-live-dev" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$(deploy_body)" 2>/dev/null || echo "{}")
+RESP3=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$GITOPS_URL/automations/start-live-dev" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$(deploy_body)" 2>/dev/null || echo "000")
+
+check "Foreign container → 409 conflict" "409" "$RESP3" "$RESP3_BODY"
+
+# Check the message is useful.
+if echo "$RESP3_BODY" | grep -q "already exists"; then
+    echo "  PASS error message contains 'already exists'"
+    ((PASS++)) || true
+else
+    echo "  FAIL error message missing 'already exists': $RESP3_BODY"
+    ((FAIL++)) || true
+fi
+
+# Clean up the foreign container.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+echo "    Foreign container removed."
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]

--- a/scripts/test_deployment_conflict.sh
+++ b/scripts/test_deployment_conflict.sh
@@ -129,6 +129,21 @@ wait_for_label() {
     return 1
 }
 
+# ── wait for a deploy task to reach completed or failed ───────────────────────
+wait_for_task() {
+    local task_id="$1" timeout="${2:-60}"
+    local i=0 status=""
+    while (( i < timeout )); do
+        status=$(curl -s "$GITOPS_URL/automations/deploy-status/$task_id" \
+            -H "$AUTH_HEADER" 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+        [[ "$status" == "completed" || "$status" == "failed" ]] && return 0
+        sleep 2; ((i += 2))
+    done
+    echo "    (task $task_id still '$status' after ${timeout}s)"
+    return 1
+}
+
 # ── Scenario A ────────────────────────────────────────────────────────────────
 echo ""
 echo "=== Scenario A: redeployment of our own automation ==="
@@ -137,20 +152,39 @@ echo "    Two deploys of '$REL_PATH' — second should succeed (202)."
 http_post "$GITOPS_URL/automations/start-live-dev" "$DEPLOY_BODY"
 echo "  First deploy: HTTP $RESP_STATUS  body: $RESP_BODY"
 
-# Wait for the first deploy's container to appear before firing the second.
-if [[ -n "$DEP_ID" ]]; then
-    echo "    Waiting for container (label gitops.deployment_id=$DEP_ID)..."
-    wait_for_label "gitops.deployment_id=$DEP_ID" 25 || echo "    (container not seen — continuing anyway)"
+# Extract deployment_id from the response if the scan didn't return one.
+if [[ -z "$DEP_ID" ]]; then
+    DEP_ID=$(echo "$RESP_BODY" | python3 -c \
+        "import sys,json; print(json.load(sys.stdin).get('deployment_id',''))" 2>/dev/null || echo "")
+fi
+TASK1_ID=$(echo "$RESP_BODY" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('task_id',''))" 2>/dev/null || echo "")
+
+# Wait for the first deploy to finish before firing the second.
+if [[ -n "$TASK1_ID" ]]; then
+    echo "    Waiting for first deploy to complete (task $TASK1_ID)..."
+    wait_for_task "$TASK1_ID" 60 || echo "    (timed out — continuing anyway)"
+elif [[ -n "$DEP_ID" ]]; then
+    wait_for_label "gitops.deployment_id=$DEP_ID" 30 || echo "    (container not seen — continuing anyway)"
 else
-    sleep 6
+    sleep 8
 fi
 
 http_post "$GITOPS_URL/automations/start-live-dev" "$DEPLOY_BODY"
 check "Second deploy of same automation succeeds (no 409)" "202" "$RESP_STATUS" "$RESP_BODY"
+TASK2_ID=$(echo "$RESP_BODY" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('task_id',''))" 2>/dev/null || echo "")
 
 # ── Scenario B ────────────────────────────────────────────────────────────────
 echo ""
 echo "=== Scenario B: foreign container blocking the deployment name ==="
+
+# Wait for the second deploy to finish so the deploy slot is free and the
+# container exists with its label before we replace it with a foreign one.
+if [[ -n "$TASK2_ID" ]]; then
+    echo "    Waiting for second deploy to complete (task $TASK2_ID)..."
+    wait_for_task "$TASK2_ID" 60 || echo "    (timed out — continuing anyway)"
+fi
 
 # Get the actual container name via the gitops.deployment_id label — this accounts
 # for the 4-char context hash that the simplified name derivation misses.


### PR DESCRIPTION
## Summary

- **Moves the container conflict pre-flight check into the route handler** so it can actually return HTTP 409 to the caller. Previously the check lived inside `start_live_dev_deployment`, which runs in a `_spawn_bg` background asyncio task — the 202 response is already sent before the task starts, so any `HTTPException` raised there was silently swallowed.
- **Scenario A** (redeploying our own automation): removes the existing container in the route handler before reserving the deploy slot, so `docker compose up` can recreate it cleanly. A lightweight race-condition guard remains in the service method.
- **Scenario B** (foreign container occupying the name): route handler now returns `409` with a clear `"A container named '...' already exists but is not managed by this GitOps instance"` message before a deploy slot is ever created.
- **Rewrites `scripts/test_deployment_conflict.sh`**:
  - Auto-detects gitops container IP when `localhost:8079` is not published to the host (normal in the bitswan stack)
  - Fixes triple-request bug (body + status were captured in two separate curl calls, firing the deploy three times)
  - Derives Scenario B container name via `docker ps --filter label=gitops.deployment_id=...` instead of guessing the name without the 4-char context hash
  - Adds `wait_for_task` polling via `GET /automations/deploy-status/{task_id}` after Scenario A's second deploy

## Known issue / remaining failure

```
FAIL error message missing 'already exists': {"detail":"Deployment internal-frontend-process-live-dev is already in progress"}
```

Scenario B fires while Scenario A's second deploy is still running. The `deploy_manager.is_deploying()` guard in the route handler fires before the container pre-flight check is reached, returning the wrong 409 message. The `wait_for_task` polling added to the script should resolve this in practice, but needs a full test run to confirm.

## Test plan

- [ ] Run `bash scripts/test_deployment_conflict.sh` against a live bitswan stack
- [ ] Scenario A: two successive deploys of the same automation both return 202
- [ ] Scenario B: busybox container occupying the target name → 409 with `"already exists"` in message
- [ ] Confirm no regression on normal deploy path (no pre-existing container)
- [ ] Verify `chown` / `git remote show origin` log noise fixes (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)