### PR TITLE
Business processes, templates, worktree status, and SSE broadcasting

### DIFF
--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -58,8 +58,38 @@ async def _broadcast_worktrees() -> None:
         logger.warning("Failed to broadcast worktrees: %s", e)
 
 
+async def _broadcast_automations() -> None:
+    """Push the current `automations` snapshot over the SSE feed.
+
+    Driven by the filesystem watchers (when `bitswan.yaml` or any
+    `automation.toml` changes) and by the Docker event watcher. Reads from
+    `AutomationService.get_automations()` which now consults the scope-keyed
+    cache and overlays live Docker state on read.
+    """
+    try:
+        automations = await get_automation_service().get_automations()
+        data = [
+            a.model_dump(mode="json") if hasattr(a, "model_dump") else a
+            for a in automations
+        ]
+        await event_broadcaster.broadcast("automations", data)
+    except Exception as e:
+        logger.warning("Failed to broadcast automations: %s", e)
+
+
 class WorkspaceChangeHandler(FileSystemEventHandler):
-    """Handle file system changes in the workspace directory."""
+    """Handle file system changes in the workspace directory.
+
+    Two parallel pipelines:
+      - process refresh (`process.toml` create/delete/move, plus directory
+        events that add/remove BPs).
+      - automation refresh (`automation.toml` / `bitswan.yaml` changes).
+
+    Both share the same coarse "anything happened" trigger for create/
+    delete/move events, since those almost always coincide with BP or
+    automation creation. `on_modified` is filtered by basename so editing
+    a python file inside an automation doesn't fire either refresh.
+    """
 
     def __init__(self, client, event_loop):
         super().__init__()
@@ -67,9 +97,11 @@ class WorkspaceChangeHandler(FileSystemEventHandler):
         self.event_loop = event_loop
         self.update_scheduled = False
         self.update_lock = threading.Lock()
+        self.automations_scheduled = False
+        self.automations_lock = threading.Lock()
 
     def schedule_update(self):
-        """Schedule an update to avoid multiple rapid updates."""
+        """Schedule a process-cache refresh + broadcast (debounced 500ms)."""
         with self.update_lock:
             if self.update_scheduled:
                 return
@@ -91,36 +123,82 @@ class WorkspaceChangeHandler(FileSystemEventHandler):
 
         asyncio.run_coroutine_threadsafe(delayed_update(), self.event_loop)
 
+    def schedule_automations_update(self):
+        """Schedule an automation-cache refresh + broadcast (debounced 500ms).
+
+        Runs independently of the process pipeline so concurrent events don't
+        clobber each other. `refresh_all` is cheap (single bitswan.yaml read
+        + per-scope filesystem scan).
+        """
+        with self.automations_lock:
+            if self.automations_scheduled:
+                return
+            self.automations_scheduled = True
+
+        async def delayed_update():
+            await asyncio.sleep(0.5)
+            try:
+                await get_automation_service().refresh_all()
+                await _broadcast_automations()
+            except Exception as e:
+                logger.warning("Error refreshing automations: %s", e)
+            finally:
+                with self.automations_lock:
+                    self.automations_scheduled = False
+
+        asyncio.run_coroutine_threadsafe(delayed_update(), self.event_loop)
+
     def on_created(self, event):
         self.schedule_update()
+        self.schedule_automations_update()
 
     def on_deleted(self, event):
         self.schedule_update()
+        self.schedule_automations_update()
 
     def on_moved(self, event):
         self.schedule_update()
+        self.schedule_automations_update()
 
     def on_modified(self, event):
-        if event.src_path.endswith("process.toml"):
+        src = getattr(event, "src_path", "") or ""
+        if src.endswith("process.toml"):
             self.schedule_update()
+        if src.endswith("automation.toml") or src.endswith("bitswan.yaml"):
+            self.schedule_automations_update()
 
 
 class WorktreeChangeHandler(FileSystemEventHandler):
     """Watch worktree directories for file changes and broadcast via SSE.
 
-    Beyond the existing `worktrees` ping event, this also keeps the
-    per-worktree `ProcessService` cache fresh and broadcasts the unified
-    `processes` snapshot. The worktree name is derived from the event path
-    so we only re-scan the affected worktree (cheap) rather than every one.
+    Narrowly filtered so editing code inside an automation doesn't fire any
+    refresh — only events that meaningfully change the state we publish:
+      - worktrees-list ping: events at the worktrees root (worktree added /
+        removed), or events under a worktree's `.git/` (commit detection,
+        which flips `synced` / `commit_hash`).
+      - per-worktree process refresh: `process.toml` events.
+      - per-worktree automation refresh: `automation.toml` events.
+      - per-worktree automation refresh-all on `bitswan.yaml` events
+        (defensive — bitswan.yaml normally lives at the gitops root, not
+        inside a worktree).
+
+    The worktree name is derived from the event path so we only re-scan the
+    affected scope.
     """
+
+    # Path-suffix markers that flip git state we publish — commits, index
+    # writes, branch tip moves. Anything else under `.git/` (e.g. pack file
+    # housekeeping) is ignored.
+    _GIT_STATE_SUFFIXES = ("/.git/HEAD", "/.git/index", "/.git/ORIG_HEAD")
+    _GIT_REFS_SEGMENT = "/.git/refs/heads/"
 
     def __init__(self, event_loop, worktrees_root: str):
         super().__init__()
         self.event_loop = event_loop
         self.worktrees_root = os.path.realpath(worktrees_root)
-        # Per-worktree debounce timers, so simultaneous edits in
-        # different worktrees don't collide.
-        self._debounce_tasks: dict[str | None, asyncio.Task] = {}
+        # Per-worktree debounce timers, one set per refresh pipeline.
+        self._process_tasks: dict[str | None, asyncio.Task] = {}
+        self._automation_tasks: dict[str | None, asyncio.Task] = {}
         # Single timer for the "ping" worktrees-list broadcast.
         self._wt_ping_task: asyncio.Task | None = None
 
@@ -137,12 +215,17 @@ class WorktreeChangeHandler(FileSystemEventHandler):
         first = rel.replace("\\", "/").split("/", 1)[0]
         return first or None
 
-    def _schedule_worktrees_ping(self):
-        """Refresh the cached worktree list and broadcast it over SSE.
+    def _is_git_state_change(self, path: str) -> bool:
+        """True for paths whose change can flip `synced` / `commit_hash`."""
+        if not path:
+            return False
+        norm = path.replace("\\", "/")
+        if norm.endswith(self._GIT_STATE_SUFFIXES):
+            return True
+        return self._GIT_REFS_SEGMENT in norm
 
-        Despite the legacy name "ping", this now carries the full data so
-        SSE consumers don't need to round-trip back to REST.
-        """
+    def _schedule_worktrees_ping(self):
+        """Refresh the cached worktree list and broadcast it over SSE."""
         async def _broadcast():
             await asyncio.sleep(1)
             await _broadcast_worktrees()
@@ -182,21 +265,74 @@ class WorktreeChangeHandler(FileSystemEventHandler):
                 )
 
         def _run():
-            existing = self._debounce_tasks.get(worktree)
+            existing = self._process_tasks.get(worktree)
             if existing and not existing.done():
                 existing.cancel()
-            self._debounce_tasks[worktree] = asyncio.ensure_future(_refresh())
+            self._process_tasks[worktree] = asyncio.ensure_future(_refresh())
+
+        self.event_loop.call_soon_threadsafe(_run)
+
+    def _schedule_automations_refresh(self, worktree: str | None):
+        """Debounced refresh + SSE broadcast for one worktree's automation cache."""
+        async def _refresh():
+            await asyncio.sleep(0.5)
+            try:
+                svc = get_automation_service()
+                if worktree is None:
+                    await svc.refresh_all()
+                else:
+                    if os.path.isdir(
+                        os.path.join(self.worktrees_root, worktree)
+                    ):
+                        await svc.refresh(worktree)
+                    else:
+                        svc.forget_worktree(worktree)
+                await _broadcast_automations()
+            except Exception as e:
+                logger.warning(
+                    "Failed to refresh worktree automations (%s): %s",
+                    worktree or "<root>",
+                    e,
+                )
+
+        def _run():
+            existing = self._automation_tasks.get(worktree)
+            if existing and not existing.done():
+                existing.cancel()
+            self._automation_tasks[worktree] = asyncio.ensure_future(_refresh())
 
         self.event_loop.call_soon_threadsafe(_run)
 
     def _handle(self, event):
-        # Always ping the worktrees list (cheap; existing consumers depend
-        # on it).
-        self._schedule_worktrees_ping()
-        # Targeted BP refresh for the affected worktree.
-        src = getattr(event, "src_path", "")
+        src = getattr(event, "src_path", "") or ""
         wt = self._worktree_from_path(src) if src else None
-        self._schedule_process_refresh(wt)
+        basename = os.path.basename(src)
+
+        # 1. Worktree-list ping: only on root events (add/remove) or git
+        #    state changes (commit, index write, ref update) — NOT on every
+        #    code edit inside a worktree.
+        if wt is None or self._is_git_state_change(src):
+            self._schedule_worktrees_ping()
+
+        # 2. Worktree directory itself appearing / disappearing → full
+        #    refresh of both pipelines so the new scope is picked up (or
+        #    stale scope dropped).
+        if wt is None:
+            self._schedule_process_refresh(None)
+            self._schedule_automations_refresh(None)
+            return
+
+        # 3. Targeted refresh by file basename. Skip everything else (code
+        #    edits, asset writes, etc.) to keep noise off the SSE feed.
+        if basename == "process.toml":
+            self._schedule_process_refresh(wt)
+        if basename == "automation.toml":
+            self._schedule_automations_refresh(wt)
+        if basename == "bitswan.yaml":
+            # bitswan.yaml normally lives at the gitops root, not under a
+            # worktree, but treat any in-worktree occurrence as a global
+            # automation-state change.
+            self._schedule_automations_refresh(None)
 
     def on_created(self, event):
         self._handle(event)
@@ -212,17 +348,14 @@ class WorktreeChangeHandler(FileSystemEventHandler):
 
 
 async def _broadcast_automations_after_delay():
-    """Debounced broadcast of automation state after Docker events settle."""
+    """Debounced broadcast of automation state after Docker events settle.
+
+    Cache is unchanged here — `get_automations()` overlays live Docker state
+    on the static cache on every call, so a Docker event just needs to
+    trigger a re-broadcast.
+    """
     await asyncio.sleep(0.5)
-    try:
-        automations = await get_automation_service().get_automations()
-        data = [
-            a.model_dump(mode="json") if hasattr(a, "model_dump") else a
-            for a in automations
-        ]
-        await event_broadcaster.broadcast("automations", data)
-    except Exception as e:
-        logger.warning("Failed to broadcast automations: %s", e)
+    await _broadcast_automations()
 
 
 async def _docker_event_watcher():
@@ -319,6 +452,14 @@ async def lifespan(app: FastAPI):
         # `publish_processes` (MQTT) and `_broadcast_processes` (SSE) read
         # from it.
         process_service.refresh_all()
+
+        # Warm the AutomationService scope-keyed cache. Cheap (filesystem
+        # scan + bitswan.yaml read) and means the first GET /automations/
+        # or SSE consumer doesn't pay for an inline `refresh_all()`.
+        try:
+            await get_automation_service().refresh_all()
+        except Exception as e:
+            logger.warning("Initial automations cache warm failed: %s", e)
 
         # Warm the worktree-list cache so the first SSE consumer doesn't
         # pay the git-cost of an initial scan.

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -22,10 +22,7 @@ from .mqtt_processes import (
     publish_processes,
     setup_mqtt_subscriptions,
 )
-from .routes.worktrees import (
-    get_cached_worktrees,
-    refresh_worktrees,
-)
+from .routes.worktrees import refresh_worktrees
 
 logger = logging.getLogger(__name__)
 

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -18,11 +18,44 @@ from .event_broadcaster import event_broadcaster
 from .mqtt import mqtt_resource
 from .mqtt_publish_automations import publish_automations
 from .mqtt_processes import (
+    process_service,
     publish_processes,
     setup_mqtt_subscriptions,
 )
+from .routes.worktrees import (
+    get_cached_worktrees,
+    refresh_worktrees,
+)
 
 logger = logging.getLogger(__name__)
+
+
+async def _broadcast_processes() -> None:
+    """Push the current `processes` snapshot over the SSE feed.
+
+    Consumed by the workspace dashboard so it never has to walk the
+    filesystem itself. Driven from both `WorkspaceChangeHandler` (main repo)
+    and `WorktreeChangeHandler` (per-worktree).
+    """
+    try:
+        await event_broadcaster.broadcast(
+            "processes", process_service.get_all_processes()
+        )
+    except Exception as e:
+        logger.warning("Failed to broadcast processes: %s", e)
+
+
+async def _broadcast_worktrees() -> None:
+    """Push the current `worktrees` snapshot over the SSE feed.
+
+    Carries the same payload as `GET /worktrees/`. Driven by
+    `WorktreeChangeHandler` so the dashboard never has to poll.
+    """
+    try:
+        worktrees = await refresh_worktrees()
+        await event_broadcaster.broadcast("worktrees", worktrees)
+    except Exception as e:
+        logger.warning("Failed to broadcast worktrees: %s", e)
 
 
 class WorkspaceChangeHandler(FileSystemEventHandler):
@@ -42,13 +75,16 @@ class WorkspaceChangeHandler(FileSystemEventHandler):
                 return
             self.update_scheduled = True
 
-        # Use asyncio.sleep to debounce updates
         async def delayed_update():
-            await asyncio.sleep(0.5)  # Wait 500ms for multiple events
+            await asyncio.sleep(0.5)  # debounce 500ms for bursts
             try:
+                # Refresh the main-repo BP cache before downstream publishers
+                # read from it.
+                process_service.refresh(None)
                 await publish_processes(self.client)
+                await _broadcast_processes()
             except Exception as e:
-                print(f"Error publishing processes: {e}")
+                logger.warning("Error publishing processes: %s", e)
             finally:
                 with self.update_lock:
                     self.update_scheduled = False
@@ -70,39 +106,109 @@ class WorkspaceChangeHandler(FileSystemEventHandler):
 
 
 class WorktreeChangeHandler(FileSystemEventHandler):
-    """Watch worktree directories for file changes and broadcast via SSE."""
+    """Watch worktree directories for file changes and broadcast via SSE.
 
-    def __init__(self, event_loop):
+    Beyond the existing `worktrees` ping event, this also keeps the
+    per-worktree `ProcessService` cache fresh and broadcasts the unified
+    `processes` snapshot. The worktree name is derived from the event path
+    so we only re-scan the affected worktree (cheap) rather than every one.
+    """
+
+    def __init__(self, event_loop, worktrees_root: str):
         super().__init__()
         self.event_loop = event_loop
-        self._debounce_task: asyncio.Task | None = None
+        self.worktrees_root = os.path.realpath(worktrees_root)
+        # Per-worktree debounce timers, so simultaneous edits in
+        # different worktrees don't collide.
+        self._debounce_tasks: dict[str | None, asyncio.Task] = {}
+        # Single timer for the "ping" worktrees-list broadcast.
+        self._wt_ping_task: asyncio.Task | None = None
 
-    def _schedule_broadcast(self):
+    def _worktree_from_path(self, path: str) -> str | None:
+        """Return the name of the worktree containing `path`, or None when
+        the event is at the worktrees root (e.g. a worktree being added /
+        removed)."""
+        try:
+            rel = os.path.relpath(os.path.realpath(path), self.worktrees_root)
+        except ValueError:
+            return None
+        if rel == "." or rel.startswith(".."):
+            return None
+        first = rel.replace("\\", "/").split("/", 1)[0]
+        return first or None
+
+    def _schedule_worktrees_ping(self):
+        """Refresh the cached worktree list and broadcast it over SSE.
+
+        Despite the legacy name "ping", this now carries the full data so
+        SSE consumers don't need to round-trip back to REST.
+        """
         async def _broadcast():
-            await asyncio.sleep(1)  # debounce 1s
-            try:
-                await event_broadcaster.broadcast("worktrees", {})
-            except Exception as e:
-                logger.warning("Failed to broadcast worktree change: %s", e)
+            await asyncio.sleep(1)
+            await _broadcast_worktrees()
 
         def _run():
-            if self._debounce_task and not self._debounce_task.done():
-                self._debounce_task.cancel()
-            self._debounce_task = asyncio.ensure_future(_broadcast())
+            if self._wt_ping_task and not self._wt_ping_task.done():
+                self._wt_ping_task.cancel()
+            self._wt_ping_task = asyncio.ensure_future(_broadcast())
 
         self.event_loop.call_soon_threadsafe(_run)
 
+    def _schedule_process_refresh(self, worktree: str | None):
+        """Debounced refresh + SSE broadcast for one worktree's BP cache.
+
+        `worktree=None` means the event hit the worktrees root itself — a
+        worktree was probably added or removed. Refresh the full set so the
+        cache reflects the new shape, then broadcast.
+        """
+        async def _refresh():
+            await asyncio.sleep(0.5)
+            try:
+                if worktree is None:
+                    process_service.refresh_all()
+                else:
+                    if os.path.isdir(
+                        os.path.join(self.worktrees_root, worktree)
+                    ):
+                        process_service.refresh(worktree)
+                    else:
+                        process_service.forget_worktree(worktree)
+                await _broadcast_processes()
+            except Exception as e:
+                logger.warning(
+                    "Failed to refresh worktree processes (%s): %s",
+                    worktree or "<root>",
+                    e,
+                )
+
+        def _run():
+            existing = self._debounce_tasks.get(worktree)
+            if existing and not existing.done():
+                existing.cancel()
+            self._debounce_tasks[worktree] = asyncio.ensure_future(_refresh())
+
+        self.event_loop.call_soon_threadsafe(_run)
+
+    def _handle(self, event):
+        # Always ping the worktrees list (cheap; existing consumers depend
+        # on it).
+        self._schedule_worktrees_ping()
+        # Targeted BP refresh for the affected worktree.
+        src = getattr(event, "src_path", "")
+        wt = self._worktree_from_path(src) if src else None
+        self._schedule_process_refresh(wt)
+
     def on_created(self, event):
-        self._schedule_broadcast()
+        self._handle(event)
 
     def on_deleted(self, event):
-        self._schedule_broadcast()
+        self._handle(event)
 
     def on_modified(self, event):
-        self._schedule_broadcast()
+        self._handle(event)
 
     def on_moved(self, event):
-        self._schedule_broadcast()
+        self._handle(event)
 
 
 async def _broadcast_automations_after_delay():
@@ -209,6 +315,18 @@ async def lifespan(app: FastAPI):
         # Set up MQTT subscriptions for process operations
         await setup_mqtt_subscriptions(client)
 
+        # Warm the ProcessService cache before publishing anything — both
+        # `publish_processes` (MQTT) and `_broadcast_processes` (SSE) read
+        # from it.
+        process_service.refresh_all()
+
+        # Warm the worktree-list cache so the first SSE consumer doesn't
+        # pay the git-cost of an initial scan.
+        try:
+            await refresh_worktrees()
+        except Exception as e:
+            logger.warning("Initial worktrees cache warm failed: %s", e)
+
         # Publish processes and automations
         await publish_processes(client)
         await publish_automations(client)
@@ -235,7 +353,9 @@ async def lifespan(app: FastAPI):
         # Watch worktree directories for file changes → SSE push
         worktrees_dir = os.path.join(workspace_dir, "worktrees")
         if os.path.exists(worktrees_dir):
-            wt_handler = WorktreeChangeHandler(asyncio.get_event_loop())
+            wt_handler = WorktreeChangeHandler(
+                asyncio.get_event_loop(), worktrees_dir
+            )
             worktree_observer = Observer()
             worktree_observer.schedule(wt_handler, worktrees_dir, recursive=True)
             worktree_observer.start()

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -226,6 +226,7 @@ class WorktreeChangeHandler(FileSystemEventHandler):
 
     def _schedule_worktrees_ping(self):
         """Refresh the cached worktree list and broadcast it over SSE."""
+
         async def _broadcast():
             await asyncio.sleep(1)
             await _broadcast_worktrees()
@@ -244,15 +245,14 @@ class WorktreeChangeHandler(FileSystemEventHandler):
         worktree was probably added or removed. Refresh the full set so the
         cache reflects the new shape, then broadcast.
         """
+
         async def _refresh():
             await asyncio.sleep(0.5)
             try:
                 if worktree is None:
                     process_service.refresh_all()
                 else:
-                    if os.path.isdir(
-                        os.path.join(self.worktrees_root, worktree)
-                    ):
+                    if os.path.isdir(os.path.join(self.worktrees_root, worktree)):
                         process_service.refresh(worktree)
                     else:
                         process_service.forget_worktree(worktree)
@@ -274,6 +274,7 @@ class WorktreeChangeHandler(FileSystemEventHandler):
 
     def _schedule_automations_refresh(self, worktree: str | None):
         """Debounced refresh + SSE broadcast for one worktree's automation cache."""
+
         async def _refresh():
             await asyncio.sleep(0.5)
             try:
@@ -281,9 +282,7 @@ class WorktreeChangeHandler(FileSystemEventHandler):
                 if worktree is None:
                     await svc.refresh_all()
                 else:
-                    if os.path.isdir(
-                        os.path.join(self.worktrees_root, worktree)
-                    ):
+                    if os.path.isdir(os.path.join(self.worktrees_root, worktree)):
                         await svc.refresh(worktree)
                     else:
                         svc.forget_worktree(worktree)
@@ -494,9 +493,7 @@ async def lifespan(app: FastAPI):
         # Watch worktree directories for file changes → SSE push
         worktrees_dir = os.path.join(workspace_dir, "worktrees")
         if os.path.exists(worktrees_dir):
-            wt_handler = WorktreeChangeHandler(
-                asyncio.get_event_loop(), worktrees_dir
-            )
+            wt_handler = WorktreeChangeHandler(asyncio.get_event_loop(), worktrees_dir)
             worktree_observer = Observer()
             worktree_observer.schedule(wt_handler, worktrees_dir, recursive=True)
             worktree_observer.start()

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -209,7 +209,10 @@ class WorktreeChangeHandler(FileSystemEventHandler):
             return None
         if rel == "." or rel.startswith(".."):
             return None
-        first = rel.replace("\\", "/").split("/", 1)[0]
+        parts = rel.replace("\\", "/").split("/")
+        if len(parts) <= 1:
+            return None
+        first = parts[0]
         return first or None
 
     def _is_git_state_change(self, path: str) -> bool:

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.routes.processes import router as processes_router
 from app.routes.worktrees import router as worktrees_router
 from app.routes.agent import router as agent_router
 from app.routes.backups import router as backups_router
+from app.routes.templates import router as templates_router
 from app.dependencies import verify_token
 
 
@@ -50,7 +51,11 @@ async def log_slow_requests(request: Request, call_next):
     return response
 
 
-# Apply auth to protected routes only
+# Apply auth to protected routes only.
+# Templates router is registered BEFORE automations router so its concrete
+# `POST /automations/from-template` route wins against the parameterised
+# `POST /automations/{deployment_id}` catch-all in the automations router.
+app.include_router(templates_router, dependencies=[Depends(verify_token)])
 app.include_router(automations_router, dependencies=[Depends(verify_token)])
 app.include_router(images_router, dependencies=[Depends(verify_token)])
 app.include_router(jupyter_router, dependencies=[Depends(verify_token)])

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.routes.jupyter import router as jupyter_router
 from app.routes.services import router as services_router
 from app.routes.docs import router as docs_router
 from app.routes.events import router as events_router
+from app.routes.processes import router as processes_router
 from app.routes.worktrees import router as worktrees_router
 from app.routes.agent import router as agent_router
 from app.routes.backups import router as backups_router
@@ -55,6 +56,7 @@ app.include_router(images_router, dependencies=[Depends(verify_token)])
 app.include_router(jupyter_router, dependencies=[Depends(verify_token)])
 app.include_router(services_router, dependencies=[Depends(verify_token)])
 app.include_router(events_router, dependencies=[Depends(verify_token)])
+app.include_router(processes_router, dependencies=[Depends(verify_token)])
 app.include_router(worktrees_router, dependencies=[Depends(verify_token)])
 # Docs router is public - no auth required
 app.include_router(docs_router)

--- a/app/mqtt_processes.py
+++ b/app/mqtt_processes.py
@@ -4,6 +4,7 @@ import toml
 import re
 import base64
 import asyncio
+import uuid
 from typing import Dict, Any, Optional, Match, Coroutine
 from paho.mqtt import client as mqtt_client
 
@@ -43,33 +44,51 @@ class ProcessService:
         self.workspace_repo_dir = os.environ.get(
             "BITSWAN_WORKSPACE_REPO_DIR", "/workspace-repo"
         )
+        # Per-scope cache of discovered processes. Key is the worktree name,
+        # or None for the main repo. Kept fresh by the file-system watchers
+        # in `lifespan.py` (see `WorkspaceChangeHandler` and
+        # `WorktreeChangeHandler`) so REST/SSE consumers don't pay the cost
+        # of a filesystem walk on every request.
+        self._cache: Dict[Optional[str], Dict[str, ProcessInfo]] = {}
 
-    def discover_processes(self) -> Dict[str, ProcessInfo]:
-        """Discover all business processes in the workspace."""
-        processes = {}
+    def _scope_root(self, worktree: Optional[str] = None) -> str:
+        """Filesystem root for a discovery scope."""
+        if worktree:
+            return os.path.join(self.workspace_repo_dir, "worktrees", worktree)
+        return self.workspace_repo_dir
 
-        if not os.path.exists(self.workspace_repo_dir):
-            logger.warning(
-                f"Workspace repository directory does not exist: {self.workspace_repo_dir}"
-            )
+    def discover_processes(
+        self, worktree: Optional[str] = None
+    ) -> Dict[str, ProcessInfo]:
+        """Discover business processes in the main repo or a single worktree.
+
+        A directory qualifies as a BP when it contains both `process.toml`
+        and `README.md`, and the toml declares a `process-id` (matches the
+        existing MQTT contract).
+        """
+        processes: Dict[str, ProcessInfo] = {}
+        root = self._scope_root(worktree)
+
+        if not os.path.exists(root):
             return processes
 
-        for item in os.listdir(self.workspace_repo_dir):
-            process_path = os.path.join(self.workspace_repo_dir, item)
+        for item in os.listdir(root):
+            # Never descend into the worktrees tree when scanning the main repo.
+            if worktree is None and item == "worktrees":
+                continue
+            process_path = os.path.join(root, item)
             if not os.path.isdir(process_path):
                 continue
 
             process_toml_path = os.path.join(process_path, "process.toml")
             process_md_path = os.path.join(process_path, "README.md")
 
-            # Check if this is a valid process directory
             if not (
                 os.path.exists(process_toml_path) and os.path.exists(process_md_path)
             ):
                 continue
 
             try:
-                # Read process.toml to get process-id
                 with open(process_toml_path, "r") as f:
                     process_config = toml.load(f)
                     process_id = process_config.get("process-id")
@@ -85,10 +104,92 @@ class ProcessService:
                 )
 
             except Exception as e:
-                logger.error(f"Error reading process {item}: {e}")
+                logger.error(
+                    f"Error reading process {item} "
+                    f"(worktree={worktree or 'main'}): {e}"
+                )
                 continue
 
         return processes
+
+    # --- In-memory cache + refresh -----------------------------------------
+
+    def refresh(self, worktree: Optional[str] = None) -> Dict[str, ProcessInfo]:
+        """Re-scan one scope and update the cache. Returns the new mapping."""
+        result = self.discover_processes(worktree)
+        self._cache[worktree] = result
+        return result
+
+    def refresh_all(self) -> None:
+        """Warm the cache from scratch: main repo + every worktree on disk."""
+        self.refresh(None)
+        worktrees_root = os.path.join(self.workspace_repo_dir, "worktrees")
+        if not os.path.isdir(worktrees_root):
+            # Drop any stale worktree entries (e.g. all worktrees removed).
+            for key in [k for k in self._cache.keys() if k is not None]:
+                self._cache.pop(key, None)
+            return
+        live = set()
+        for entry in os.listdir(worktrees_root):
+            if entry.startswith("."):
+                continue
+            full = os.path.join(worktrees_root, entry)
+            if not os.path.isdir(full):
+                continue
+            live.add(entry)
+            self.refresh(entry)
+        # Forget worktrees that have disappeared since the last refresh.
+        for stale in [k for k in self._cache.keys() if k and k not in live]:
+            self._cache.pop(stale, None)
+
+    def forget_worktree(self, worktree: str) -> None:
+        """Drop a worktree's cache entry (used when the worktree is removed)."""
+        self._cache.pop(worktree, None)
+
+    def get_all_processes(self) -> list[dict]:
+        """Flat, dedup-by-directory-name list of every known BP.
+
+        Each entry:
+            {
+              "id":        process-id (from toml),
+              "name":      directory name (filesystem-safe),
+              "in_main":   bool — present in the main repo,
+              "worktrees": list of worktree names where the same directory
+                           name has a valid BP,
+              "has_worktrees": derived (worktrees != []),
+            }
+
+        Worktree-only BPs surface as `in_main: false, worktrees: [<wt>]`.
+        """
+        # Build directory-name -> {in_main, worktrees, process_id} aggregations.
+        by_name: Dict[str, dict] = {}
+        for scope, processes in self._cache.items():
+            for info in processes.values():
+                entry = by_name.setdefault(
+                    info.name,
+                    {"id": info.id, "in_main": False, "worktrees": []},
+                )
+                if scope is None:
+                    entry["in_main"] = True
+                    # Main always wins as the canonical id source.
+                    entry["id"] = info.id
+                else:
+                    entry["worktrees"].append(scope)
+
+        out: list[dict] = []
+        for name in sorted(by_name):
+            entry = by_name[name]
+            entry["worktrees"].sort()
+            out.append(
+                {
+                    "id": entry["id"],
+                    "name": name,
+                    "in_main": entry["in_main"],
+                    "worktrees": entry["worktrees"],
+                    "has_worktrees": bool(entry["worktrees"]),
+                }
+            )
+        return out
 
     def get_process_attachments(self, process_id: str) -> list[str]:
         """Get attachments for a specific process."""
@@ -302,26 +403,77 @@ class ProcessService:
         return False
 
     def create_process(self, process_id: str, process_name: str) -> bool:
-        """Create a new process."""
-        # Sanitize process_name to prevent path traversal
-        process_name = os.path.basename(process_name.strip())
-        if not process_name:
-            logger.error(
-                f"Failed to create process {process_id}: process_name is empty or invalid"
-            )
-            return False
+        """Create a new process (MQTT-callable, main-repo only).
 
+        Thin wrapper around `create_business_process` kept for backwards
+        compatibility with the existing MQTT handler.
+        """
         try:
-            process_dir = os.path.join(self.workspace_repo_dir, process_name)
-            os.makedirs(process_dir)
-            with open(os.path.join(process_dir, "process.toml"), "w") as f:
-                f.write(f'process-id = "{process_id}"\n')
-            with open(os.path.join(process_dir, "README.md"), "w") as f:
-                f.write(f"# {process_name}\n")
+            self.create_business_process(
+                name=process_name, worktree=None, process_id=process_id
+            )
             return True
         except Exception as e:
             logger.error(f"Error creating process {process_name}: {e}")
             return False
+
+    def create_business_process(
+        self,
+        name: str,
+        worktree: Optional[str] = None,
+        process_id: Optional[str] = None,
+    ) -> dict:
+        """Create a new business-process directory with a `process.toml` +
+        `README.md` template inside the main repo or a specific worktree.
+
+        Returns the entry as it appears in `get_all_processes()`.
+        """
+        # Strip + basename to defend against path traversal. The HTTP route
+        # additionally validates the input against a regex, but this keeps
+        # the MQTT call path safe too.
+        clean = os.path.basename((name or "").strip())
+        if not clean:
+            raise ValueError("process name is empty or invalid")
+
+        if worktree:
+            scope_root = os.path.join(
+                self.workspace_repo_dir, "worktrees", worktree
+            )
+            if not os.path.isdir(scope_root):
+                raise FileNotFoundError(
+                    f"worktree '{worktree}' does not exist"
+                )
+        else:
+            scope_root = self.workspace_repo_dir
+
+        process_dir = os.path.join(scope_root, clean)
+        if os.path.exists(process_dir):
+            raise FileExistsError(
+                f"a directory named '{clean}' already exists in "
+                f"{'worktree ' + worktree if worktree else 'main'}"
+            )
+
+        pid = process_id or str(uuid.uuid4())
+
+        os.makedirs(process_dir)
+        with open(os.path.join(process_dir, "process.toml"), "w") as f:
+            f.write(f'process-id = "{pid}"\n')
+        with open(os.path.join(process_dir, "README.md"), "w") as f:
+            f.write(f"# {clean}\n")
+
+        # Refresh just the affected scope so the next discovery call sees
+        # the new BP. The HTTP route is expected to broadcast the snapshot
+        # over SSE after this returns; we keep the cache update local to
+        # avoid coupling the service to the broadcaster.
+        self.refresh(worktree)
+
+        return {
+            "id": pid,
+            "name": clean,
+            "in_main": worktree is None,
+            "worktrees": [worktree] if worktree else [],
+            "has_worktrees": bool(worktree),
+        }
 
 
 # Global process service instance
@@ -386,9 +538,17 @@ def match_topic(topic: str) -> tuple[str, Match[str] | None]:
 
 
 async def publish_processes(client: mqtt_client.Client) -> ProcessList:
-    """Publish the list of processes to MQTT."""
+    """Publish the list of (main-repo) processes to MQTT.
+
+    Driven by the cached main-repo entry — `WorkspaceChangeHandler` refreshes
+    that entry before invoking us. Worktree processes are not (yet) published
+    via this MQTT topic; they're surfaced over the new SSE `processes` event
+    for the dashboard.
+    """
     topic = "/processes/list"
-    processes = process_service.discover_processes()
+    processes = process_service._cache.get(None)
+    if processes is None:
+        processes = process_service.refresh(None)
 
     process_list = ProcessList(processes=processes)
 

--- a/app/mqtt_processes.py
+++ b/app/mqtt_processes.py
@@ -105,8 +105,7 @@ class ProcessService:
 
             except Exception as e:
                 logger.error(
-                    f"Error reading process {item} "
-                    f"(worktree={worktree or 'main'}): {e}"
+                    f"Error reading process {item} (worktree={worktree or 'main'}): {e}"
                 )
                 continue
 
@@ -436,13 +435,9 @@ class ProcessService:
             raise ValueError("process name is empty or invalid")
 
         if worktree:
-            scope_root = os.path.join(
-                self.workspace_repo_dir, "worktrees", worktree
-            )
+            scope_root = os.path.join(self.workspace_repo_dir, "worktrees", worktree)
             if not os.path.isdir(scope_root):
-                raise FileNotFoundError(
-                    f"worktree '{worktree}' does not exist"
-                )
+                raise FileNotFoundError(f"worktree '{worktree}' does not exist")
         else:
             scope_root = self.workspace_repo_dir
 

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -13,7 +13,6 @@ from app.dependencies import get_automation_service
 from app.services.automation_service import (
     AutomationService,
     make_hostname_label,
-    sanitize_automation_name,
     scan_workspace_sources,
 )
 from app.utils import (
@@ -157,16 +156,6 @@ def _resolve_worktree_path(name: str) -> str:
 
 
 # --- Deployment endpoints ---
-
-
-def _sanitize_name(name: str) -> str:
-    """Sanitize an automation source name for use in deployment IDs.
-
-    Backwards-compatible alias kept so older call sites in this module keep
-    working. New code should call `sanitize_automation_name` from
-    `app.services.automation_service` directly.
-    """
-    return sanitize_automation_name(name)
 
 
 def _scan_automations(worktree: str | None = None) -> list[dict]:

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -559,7 +559,7 @@ async def build_and_restart_deployment(
 
                 # Compute content hash and build disambiguated tag
                 # matching the editor scheme: internal/{ws}-{bp}-{name}:sha{hash}
-                checksum = await calculate_git_tree_hash(image_dir)
+                checksum = await calculate_git_tree_hash([image_dir])
                 auto_name = os.path.basename(source_dir)
                 ws_name = automation_service.workspace_name or "workspace"
                 # Extract BP name from relative_path

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -13,6 +13,8 @@ from app.dependencies import get_automation_service
 from app.services.automation_service import (
     AutomationService,
     make_hostname_label,
+    sanitize_automation_name,
+    scan_workspace_sources,
 )
 from app.utils import (
     call_git_command,
@@ -158,65 +160,22 @@ def _resolve_worktree_path(name: str) -> str:
 
 
 def _sanitize_name(name: str) -> str:
-    """Sanitize an automation source name for use in deployment IDs."""
-    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
+    """Sanitize an automation source name for use in deployment IDs.
+
+    Backwards-compatible alias kept so older call sites in this module keep
+    working. New code should call `sanitize_automation_name` from
+    `app.services.automation_service` directly.
+    """
+    return sanitize_automation_name(name)
 
 
 def _scan_automations(worktree: str | None = None) -> list[dict]:
     """Scan the filesystem for automation sources (automation.toml).
 
-    If *worktree* is given, scans the worktree directory.
-    Otherwise scans the main workspace directory.
+    Thin wrapper over `scan_workspace_sources` that keeps the existing
+    `_get_workspace_dir()` resolution behaviour.
     """
-    workspace_dir = _get_workspace_dir()
-    if worktree:
-        scan_root = os.path.join(workspace_dir, "worktrees", worktree)
-    else:
-        scan_root = workspace_dir
-    if not os.path.isdir(scan_root):
-        return []
-
-    skip_dirs = {"templates", "worktrees", ".git"}
-    results = []
-    seen_ids: set[str] = set()
-    for root, dirs, files in os.walk(scan_root):
-        dirs[:] = [d for d in dirs if d not in skip_dirs]
-        if "automation.toml" in files:
-            rel_path = os.path.relpath(root, scan_root)
-            source_name = os.path.basename(root)
-            sanitized = _sanitize_name(source_name)
-            rel_parts = rel_path.replace("\\", "/").split("/")
-            bp_name = _sanitize_name(rel_parts[0]) if len(rel_parts) >= 2 else ""
-            bp_prefix = f"{bp_name}-" if bp_name else ""
-
-            if worktree:
-                bp_suffix = f"-{bp_name}" if bp_name else ""
-                context = f"wt-{worktree}{bp_suffix}"
-                deployment_id = f"{sanitized}-{context}-live-dev"
-                relative_path = f"worktrees/{worktree}/{rel_path}"
-                deploy_stage = "live-dev"
-            else:
-                context = bp_name  # just the BP name (or empty)
-                deployment_id = f"{sanitized}-{bp_prefix}live-dev"
-                relative_path = rel_path
-                deploy_stage = "live-dev"
-
-            if deployment_id in seen_ids:
-                continue
-            seen_ids.add(deployment_id)
-            results.append(
-                {
-                    "deployment_id": deployment_id,
-                    "automation_name": sanitized,
-                    "display_name": source_name,
-                    "context": context,
-                    "stage": deploy_stage,
-                    "relative_path": relative_path,
-                    "source_path": root,
-                    "worktree": worktree,
-                }
-            )
-    return results
+    return scan_workspace_sources(_get_workspace_dir(), worktree)
 
 
 @router.get("/deployments")

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -53,6 +53,66 @@ class StartLiveDevRequest(BaseModel):
     worktree: str | None = None
 
 
+class StartDeployRequest(BaseModel):
+    relative_path: str
+    stage: str  # "dev" or "live-dev"
+    worktree: str | None = None
+
+
+@router.post("/start-deploy")
+async def start_deploy(
+    body: StartDeployRequest,
+    automation_service: AutomationService = Depends(get_automation_service),
+):
+    """Deploy an automation from the bind-mounted workspace.
+
+    Replaces the editor's upload+deploy flow for environments where the
+    workspace is co-located with gitops. The body is intentionally minimal
+    (relative_path, stage, worktree?) — gitops reads the automation source
+    directly from `/workspace-repo`, merges `bitswan_lib` if present,
+    computes the merged-tree checksum, materialises `<checksum>/` if needed,
+    and kicks off the existing deploy pipeline.
+    """
+    prep = await automation_service.start_deploy_from_workspace(
+        relative_path=body.relative_path,
+        stage=body.stage,
+        worktree=body.worktree,
+    )
+
+    _spawn_bg(
+        _run_deploy_with_progress(
+            prep["task_id"],
+            prep["deployment_id"],
+            automation_service,
+            prep["deploy_kwargs"],
+        )
+    )
+
+    workspace_name = os.environ.get("BITSWAN_WORKSPACE_NAME", "workspace-local")
+    gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", "")
+    url = ""
+    if gitops_domain:
+        source = prep["source"]
+        label = make_hostname_label(
+            workspace_name,
+            source["automation_name"],
+            source["context"],
+            body.stage,
+        )
+        url = f"https://{label}.{gitops_domain}"
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "task_id": prep["task_id"],
+            "deployment_id": prep["deployment_id"],
+            "checksum": prep["checksum"],
+            "url": url,
+            "status": "pending",
+        },
+    )
+
+
 @router.post("/start-live-dev")
 async def start_live_dev(
     body: StartLiveDevRequest,

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -11,6 +11,8 @@ from fastapi.responses import StreamingResponse
 from app.dependencies import get_automation_service, get_image_service
 from app.deploy_manager import deploy_manager
 from app.event_broadcaster import event_broadcaster
+from app.mqtt_processes import process_service
+from app.routes.worktrees import get_cached_worktrees
 
 router = APIRouter(tags=["events"])
 
@@ -32,6 +34,19 @@ async def stream_events():
 
             images = await get_image_service().get_images()
             yield f"event: images\ndata: {json.dumps(images)}\n\n"
+
+            # Current business-process snapshot — the dashboard reads this
+            # straight off the SSE feed instead of walking the filesystem.
+            processes = process_service.get_all_processes()
+            yield f"event: processes\ndata: {json.dumps(processes)}\n\n"
+
+            # Current worktree list. Carried as data (not just a ping) so
+            # the dashboard doesn't need a follow-up REST round-trip.
+            try:
+                worktrees = await get_cached_worktrees()
+            except Exception:
+                worktrees = []
+            yield f"event: worktrees\ndata: {json.dumps(worktrees)}\n\n"
 
             # Send active deploy tasks so reconnecting clients pick up current state
             for task in deploy_manager.get_all_active_tasks():

--- a/app/routes/processes.py
+++ b/app/routes/processes.py
@@ -1,0 +1,85 @@
+"""
+REST surface over the workspace's business processes.
+
+Reads the in-memory cache maintained by `ProcessService`; the cache is kept
+fresh by the workspace + worktree file-system watchers in `lifespan.py`.
+Same data is broadcast over `/events/stream` as a `processes` event for
+push-style consumers (the workspace dashboard).
+"""
+
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.event_broadcaster import event_broadcaster
+from app.mqtt_processes import process_service
+
+router = APIRouter(prefix="/processes", tags=["processes"])
+
+# Mirrors the dashboard-side validation, kept tight enough that the name can
+# also stand in for a deployment_id segment without surprises.
+_PROCESS_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class CreateProcessRequest(BaseModel):
+    name: str
+    worktree: str | None = None
+
+
+@router.get("/")
+async def get_processes() -> list[dict]:
+    """Return all business processes across main repo and every worktree.
+
+    Each entry is deduplicated by directory name; the `worktrees` list says
+    which worktrees the same BP also lives in (empty when only in main).
+    A BP that exists *only* in a worktree comes back with `in_main: false`.
+    """
+    return process_service.get_all_processes()
+
+
+@router.post("/")
+async def create_process(body: CreateProcessRequest) -> dict:
+    """Create a new business-process directory.
+
+    Scaffolds `process.toml` + `README.md` under either `<workspace_repo>/<name>/`
+    or `<workspace_repo>/worktrees/<worktree>/<name>/`. The new BP surfaces
+    over the SSE feed within the same response (this route refreshes the
+    cache + broadcasts inline instead of waiting for the filesystem watcher
+    to debounce).
+    """
+    name = (body.name or "").strip()
+    if not _PROCESS_NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Invalid process name: must start with a letter or digit and "
+                "contain only letters, digits, underscores, dashes, and dots."
+            ),
+        )
+    if body.worktree is not None and not _PROCESS_NAME_RE.match(body.worktree):
+        raise HTTPException(status_code=400, detail="Invalid worktree name")
+
+    try:
+        entry = process_service.create_business_process(
+            name=name, worktree=body.worktree
+        )
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except (FileNotFoundError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to create process: {e}"
+        )
+
+    # Push the fresh snapshot to all SSE consumers so the dashboard's
+    # sidebar updates without waiting for the workspace watcher tick.
+    try:
+        await event_broadcaster.broadcast(
+            "processes", process_service.get_all_processes()
+        )
+    except Exception:
+        pass
+
+    return entry

--- a/app/routes/processes.py
+++ b/app/routes/processes.py
@@ -69,9 +69,7 @@ async def create_process(body: CreateProcessRequest) -> dict:
     except (FileNotFoundError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to create process: {e}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to create process: {e}")
 
     # Push the fresh snapshot to all SSE consumers so the dashboard's
     # sidebar updates without waiting for the workspace watcher tick.

--- a/app/routes/processes.py
+++ b/app/routes/processes.py
@@ -20,6 +20,8 @@ router = APIRouter(prefix="/processes", tags=["processes"])
 # Mirrors the dashboard-side validation, kept tight enough that the name can
 # also stand in for a deployment_id segment without surprises.
 _PROCESS_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+# Matches the canonical worktree-name constraint used by /worktrees and /templates.
+_WORKTREE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-]*$")
 
 
 class CreateProcessRequest(BaseModel):
@@ -57,7 +59,7 @@ async def create_process(body: CreateProcessRequest) -> dict:
                 "contain only letters, digits, underscores, dashes, and dots."
             ),
         )
-    if body.worktree is not None and not _PROCESS_NAME_RE.match(body.worktree):
+    if body.worktree is not None and not _WORKTREE_NAME_RE.match(body.worktree):
         raise HTTPException(status_code=400, detail="Invalid worktree name")
 
     try:

--- a/app/routes/templates.py
+++ b/app/routes/templates.py
@@ -1,0 +1,97 @@
+"""
+Automation-template gallery + scaffold endpoints.
+
+Mirror of the dashboard server's old `routes/templates.ts`. The dashboard now
+forwards `GET /api/templates` and `POST /api/automations/from-template` to
+these endpoints; gitops is the sole writer to `/workspace-repo`.
+"""
+
+import logging
+import os
+import re
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.dependencies import get_automation_service
+from app.event_broadcaster import event_broadcaster
+from app.services import template_service
+from app.services.automation_service import AutomationService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["templates"])
+
+# Same shape as the dashboard server uses for BP / worktree names.
+_BP_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_WORKTREE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-]*$")
+
+
+def _workspace_root() -> str:
+    return os.environ.get("BITSWAN_WORKSPACE_REPO_DIR", "/workspace-repo")
+
+
+@router.get("/templates/")
+async def list_templates() -> dict:
+    """Return the merged `{templates, groups}` listing."""
+    return template_service.discover_templates(_workspace_root())
+
+
+class CreateFromTemplateRequest(BaseModel):
+    template_id: str | None = None
+    group_id: str | None = None
+    name: str | None = None
+    bp: str
+    worktree: str | None = None
+
+
+@router.post("/automations/from-template")
+async def create_from_template(
+    body: CreateFromTemplateRequest,
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> dict:
+    """Copy a template (or every automation in a group) into the BP directory,
+    inject a UUID into each new `automation.toml`, commit, and broadcast the
+    fresh `automations` snapshot.
+    """
+    if not body.bp or not _BP_NAME_RE.match(body.bp):
+        raise HTTPException(status_code=400, detail="Invalid bp")
+    if body.worktree is not None and not _WORKTREE_NAME_RE.match(body.worktree):
+        raise HTTPException(status_code=400, detail="Invalid worktree name")
+    if bool(body.template_id) == bool(body.group_id):
+        raise HTTPException(
+            status_code=400,
+            detail="Exactly one of template_id / group_id is required",
+        )
+
+    try:
+        result = await template_service.create_automation_from_template(
+            workspace_root=_workspace_root(),
+            bp=body.bp,
+            template_id=body.template_id,
+            group_id=body.group_id,
+            name=body.name,
+            worktree=body.worktree,
+        )
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except (FileNotFoundError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("create_automation_from_template failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Refresh the affected scope's cache and broadcast the fresh snapshot so
+    # the dashboard's sidebar updates without waiting for the FS watcher.
+    try:
+        await automation_service.refresh(body.worktree)
+        automations = await automation_service.get_automations()
+        data = [
+            a.model_dump(mode="json") if hasattr(a, "model_dump") else a
+            for a in automations
+        ]
+        await event_broadcaster.broadcast("automations", data)
+    except Exception:
+        logger.exception("Failed to broadcast automations after template create")
+
+    return result

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -4,7 +4,7 @@ import os
 import re
 import uuid
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.async_docker import get_async_docker_client, DockerError
@@ -794,17 +794,133 @@ async def delete_worktree(name: str):
     return {"status": "success", "message": f"Worktree '{name}' deleted"}
 
 
+def _is_safe_relative_path(p: str) -> bool:
+    """True if `p` looks like a workspace-relative path (no `..`, no leading `/`)."""
+    if not p:
+        return False
+    if p.startswith("/") or p.startswith("\\"):
+        return False
+    parts = re.split(r"[\\/]", p)
+    return not any(seg in ("", "..") for seg in parts)
+
+
+# Map a porcelain status code to the simple A/M/D taxonomy the dashboard
+# renders. Renames collapse to M for now — the design only knows A/M/D.
+def _porcelain_to_kind(code: str) -> str | None:
+    """`code` is the two-char xy prefix from `git status --porcelain`."""
+    if not code:
+        return None
+    x, y = code[0], code[1] if len(code) > 1 else " "
+    # Untracked file (??)
+    if x == "?" and y == "?":
+        return "A"
+    # Deleted on either side
+    if x == "D" or y == "D":
+        return "D"
+    # Added on either side
+    if x == "A" or y == "A":
+        return "A"
+    # Renamed collapses to M for v1
+    if x == "R" or y == "R":
+        return "M"
+    # Anything else (modified, copied, type-changed) → M
+    if x == "M" or y == "M" or x == "T" or y == "T" or x == "C" or y == "C":
+        return "M"
+    return None
+
+
+@router.get("/{name}/status")
+async def get_worktree_status(name: str):
+    """Per-file change list for a worktree.
+
+    Combines `git status --porcelain=v1 -z` (which files changed and how)
+    with `git diff --numstat HEAD` (how many lines added / removed). Used
+    by the dashboard's Diff / Files tabs.
+    """
+    worktree_path = _resolve_worktree_path(name)
+    if not os.path.exists(worktree_path):
+        raise HTTPException(status_code=404, detail=f"Worktree '{name}' not found")
+
+    # `--porcelain=v1 -z` uses NUL terminators between records and never
+    # quotes file paths, so we don't need to deal with shell-quoted names.
+    status_out, status_err, status_rc = await call_git_command_with_output(
+        "git",
+        "status",
+        "--porcelain=v1",
+        "-z",
+        cwd=worktree_path,
+    )
+    if status_rc != 0:
+        raise HTTPException(
+            status_code=500, detail=f"git status failed: {status_err.strip()}"
+        )
+
+    changed: list[dict] = []
+    # Records are NUL-separated; rename entries are two records (new\0old).
+    records = status_out.split("\x00")
+    skip_next = False
+    for rec in records:
+        if skip_next:
+            skip_next = False
+            continue
+        if not rec:
+            continue
+        # Format: "XY path"  (XY is two columns)
+        code = rec[:2]
+        path = rec[3:] if len(rec) > 3 else ""
+        kind = _porcelain_to_kind(code)
+        if not kind or not path:
+            continue
+        # Rename: next NUL-delimited entry is the OLD name; skip it.
+        if code[0] == "R" or code[1] == "R":
+            skip_next = True
+        changed.append({"path": path, "kind": kind, "adds": 0, "dels": 0})
+
+    # Merge in adds/dels from `git diff --numstat HEAD`. Untracked files
+    # don't show up here (diff is against HEAD); leave their counts at 0
+    # — the user can see exact contents in the Files tab.
+    numstat_out, _, numstat_rc = await call_git_command_with_output(
+        "git", "diff", "--numstat", "HEAD", cwd=worktree_path
+    )
+    if numstat_rc == 0:
+        # Lines are `adds\tdels\tpath`. Binary files use `-\t-`.
+        by_path = {c["path"]: c for c in changed}
+        for line in numstat_out.splitlines():
+            parts = line.split("\t", 2)
+            if len(parts) != 3:
+                continue
+            adds_str, dels_str, path = parts
+            adds = int(adds_str) if adds_str.isdigit() else 0
+            dels = int(dels_str) if dels_str.isdigit() else 0
+            entry = by_path.get(path)
+            if entry is not None:
+                entry["adds"] = adds
+                entry["dels"] = dels
+
+    return {"changed": changed}
+
+
 @router.get("/{name}/diff")
-async def get_worktree_diff(name: str):
+async def get_worktree_diff(
+    name: str,
+    path: str | None = Query(None),
+):
+    """Unified diff of the worktree against its own HEAD. Optional `?path=`
+    filters to a single workspace-relative file."""
     worktree_path = _resolve_worktree_path(name)
 
     if not os.path.exists(worktree_path):
         raise HTTPException(status_code=404, detail=f"Worktree '{name}' not found")
 
-    # Diff the worktree's working tree against its own HEAD
-    stdout, stderr, rc = await call_git_command_with_output(
-        "git", "diff", "HEAD", "--", ".", cwd=worktree_path
-    )
+    git_args: list[str] = ["git", "diff", "HEAD"]
+    if path is not None:
+        if not _is_safe_relative_path(path):
+            raise HTTPException(status_code=400, detail="invalid path")
+        git_args += ["--", path]
+    else:
+        git_args += ["--", "."]
+
+    stdout, stderr, rc = await call_git_command_with_output(*git_args, cwd=worktree_path)
     if rc != 0:
         raise HTTPException(
             status_code=500,

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -380,12 +380,24 @@ async def create_worktree(body: CreateWorktreeRequest):
     return result
 
 
-@router.get("/")
-async def list_worktrees():
+# In-memory cache for the worktree list. Refreshed by the filesystem watcher
+# in `lifespan.py` whenever something under `worktrees/` changes, and
+# broadcast over the `/events/stream` SSE feed as a `worktrees` event so the
+# dashboard never has to poll. `None` means "never computed yet" — the route
+# will compute on demand.
+_worktrees_cache: list[dict] | None = None
+
+
+async def _compute_worktrees() -> list[dict]:
+    """Heavy work: shell out to git (per-worktree) and assemble the listing.
+
+    Same data the `GET /worktrees/` route used to return inline; lifted to a
+    function so both the route and the watcher-driven cache refresh share
+    the implementation.
+    """
     workspace_dir = _get_workspace_dir()
     worktrees_base = _get_worktrees_base()
 
-    # Get worktree list from git
     stdout, stderr, rc = await call_git_command_with_output(
         "git", "worktree", "list", "--porcelain", cwd=workspace_dir
     )
@@ -484,6 +496,27 @@ async def list_worktrees():
         )
 
     return result
+
+
+async def get_cached_worktrees() -> list[dict]:
+    """Return the cached worktree list, computing on first call."""
+    global _worktrees_cache
+    if _worktrees_cache is None:
+        _worktrees_cache = await _compute_worktrees()
+    return _worktrees_cache
+
+
+async def refresh_worktrees() -> list[dict]:
+    """Re-run the worktree scan and update the cache. Used by the filesystem
+    watcher whenever something under `worktrees/` changes."""
+    global _worktrees_cache
+    _worktrees_cache = await _compute_worktrees()
+    return _worktrees_cache
+
+
+@router.get("/")
+async def list_worktrees():
+    return await get_cached_worktrees()
 
 
 class MergeWorktreeResponse(BaseModel):

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -920,7 +920,9 @@ async def get_worktree_diff(
     else:
         git_args += ["--", "."]
 
-    stdout, stderr, rc = await call_git_command_with_output(*git_args, cwd=worktree_path)
+    stdout, stderr, rc = await call_git_command_with_output(
+        *git_args, cwd=worktree_path
+    )
     if rc != 0:
         raise HTTPException(
             status_code=500,

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -241,6 +241,13 @@ class AutomationService:
         )
         # Cache full history per deployment_id: {deployment_id: (commit_hash, [entries])}
         self._history_cache: dict[str, tuple[str, list]] = {}
+        # Scope-keyed cache mirroring ProcessService._cache. Key = worktree
+        # name, or None for main. Holds STATIC entries (yaml + filesystem
+        # scan); Docker container state is overlaid live by get_automations()
+        # so we don't have to couple this cache to Docker events. Refreshed
+        # by the filesystem watchers in app/lifespan.py whenever
+        # bitswan.yaml or any automation.toml changes.
+        self._cache: dict[str | None, list[DeployedAutomation]] = {}
 
     async def warm_history_cache(self):
         """Pre-warm the history cache for all known deployments."""
@@ -308,134 +315,63 @@ class AutomationService:
         )
         return containers
 
-    def _discover_workspace_sources(self) -> list[dict]:
-        """List every `automation.toml` directory under the workspace repo.
+    def _yaml_scope(self, relative_path: str | None) -> str | None:
+        """Classify a `bitswan.yaml` deployment into a cache scope.
 
-        Combines the main workspace with each worktree under
-        `<workspace_repo>/worktrees/`. Used by `get_automations()` to surface
-        automations that exist on disk but have not been deployed yet.
+        Main scope = `None` (everything not under `worktrees/`).
+        Worktree scope = the worktree's name, parsed out of the path.
         """
-        sources = scan_workspace_sources(self.workspace_repo_dir, worktree=None)
-        worktrees_root = os.path.join(self.workspace_repo_dir, "worktrees")
-        if os.path.isdir(worktrees_root):
-            for entry in os.listdir(worktrees_root):
-                if entry.startswith("."):
-                    continue
-                if not os.path.isdir(os.path.join(worktrees_root, entry)):
-                    continue
-                sources.extend(
-                    scan_workspace_sources(self.workspace_repo_dir, worktree=entry)
-                )
-        return sources
+        if not relative_path:
+            return None
+        norm = relative_path.replace("\\", "/").lstrip("/")
+        if not norm.startswith("worktrees/"):
+            return None
+        rest = norm[len("worktrees/") :]
+        wt = rest.split("/", 1)[0]
+        return wt or None
 
-    async def get_automations(self):
-        """Get all automations with their container status using async Docker client."""
-        bs_yaml = read_bitswan_yaml(self.gitops_dir)
+    def _build_static_entries(
+        self, scope: str | None, bs_yaml: dict | None
+    ) -> list[DeployedAutomation]:
+        """Build the static (yaml + scan) entries for a single scope.
 
-        if not bs_yaml:
-            bs_yaml = {"deployments": {}}
-
-        pres = {
-            deployment_id: DeployedAutomation(
-                container_id=None,
-                endpoint_name=None,
-                created_at=None,
-                name=deployment_id,
-                state=None,
-                status=None,
-                deployment_id=deployment_id,
-                active=bs_yaml["deployments"][deployment_id].get("active", False),
-                automation_url=None,
-                relative_path=bs_yaml["deployments"][deployment_id].get(
-                    "relative_path", None
-                ),
-                stage=bs_yaml["deployments"][deployment_id].get("stage", "production"),
-                automation_name=bs_yaml["deployments"][deployment_id].get(
-                    "automation_name", None
-                ),
-                context=bs_yaml["deployments"][deployment_id].get("context", None),
-                version_hash=bs_yaml["deployments"][deployment_id].get(
-                    "checksum", None
-                ),
-                replicas=bs_yaml["deployments"][deployment_id].get("replicas", 1),
-            )
-            for deployment_id in bs_yaml["deployments"]
-        }
-
-        docker_client = get_async_docker_client()
-        info = await docker_client.info()
-        containers = await self.get_containers()
-
-        gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", None)
-
-        dep_configs = bs_yaml.get("deployments", {})
-
-        # updated pres with active containers
-        for container in containers:
-            labels = container.get("Labels", {})
-            deployment_id = labels.get("gitops.deployment_id")
-            if deployment_id and deployment_id in pres:
-                label = labels.get("gitops.intended_exposed", "false")
-
-                dep_conf = dep_configs.get(deployment_id, {})
-                url = generate_workspace_url(
-                    self.workspace_name,
-                    dep_conf.get("automation_name", deployment_id),
-                    dep_conf.get("context", ""),
-                    dep_conf.get("stage", "production") or "production",
-                    gitops_domain,
-                    True,
-                )
-
-                if label != "true":
-                    url = None
-
-                # Parse created timestamp
-                created_str = container.get("Created")
-                created_at = None
-                if created_str:
-                    try:
-                        # Docker API returns Unix timestamp
-                        created_at = datetime.utcfromtimestamp(created_str)
-                    except (ValueError, TypeError):
-                        pass
-
-                # Get container state
-                state = container.get("State", "unknown")
-                status = container.get("Status", "")
-
-                pres[deployment_id] = DeployedAutomation(
-                    container_id=container.get("Id"),
-                    endpoint_name=info.get("Name"),
-                    created_at=created_at,
+        Container/state/status/url fields are left blank — Docker overlay
+        is applied live by `get_automations()` so we don't have to couple
+        the cache to Docker events.
+        """
+        deployments = (bs_yaml or {}).get("deployments", {}) or {}
+        deployed: list[DeployedAutomation] = []
+        for deployment_id, cfg in deployments.items():
+            if self._yaml_scope(cfg.get("relative_path")) != scope:
+                continue
+            deployed.append(
+                DeployedAutomation(
+                    container_id=None,
+                    endpoint_name=None,
+                    created_at=None,
                     name=deployment_id,
-                    state=state,
-                    status=status,
+                    state=None,
+                    status=None,
                     deployment_id=deployment_id,
-                    active=pres[deployment_id].active,
-                    automation_url=url,
-                    relative_path=pres[deployment_id].relative_path,
-                    stage=pres[deployment_id].stage,
-                    automation_name=pres[deployment_id].automation_name,
-                    context=pres[deployment_id].context,
-                    version_hash=pres[deployment_id].version_hash,
-                    replicas=pres[deployment_id].replicas,
+                    active=cfg.get("active", False),
+                    automation_url=None,
+                    relative_path=cfg.get("relative_path", None),
+                    stage=cfg.get("stage", "production"),
+                    automation_name=cfg.get("automation_name", None),
+                    context=cfg.get("context", None),
+                    version_hash=cfg.get("checksum", None),
+                    replicas=cfg.get("replicas", 1),
                 )
-
-        # Discoverable entries — sources that exist on disk but aren't in
-        # `bitswan.yaml`. Surfaced so the dashboard can offer a Deploy button
-        # for them. Matched by automation_name + relative_path against any
-        # already-deployed entry; matched ones are dropped (the deployed entry
-        # already covers them).
-        deployed_keys = {
-            (
-                (p.automation_name or "").lower(),
-                (p.relative_path or "").rstrip("/"),
             )
-            for p in pres.values()
+
+        # Discoverable: on-disk automations not represented in bitswan.yaml,
+        # matched by (automation_name, relative_path) — same key as before.
+        deployed_keys = {
+            ((d.automation_name or "").lower(), (d.relative_path or "").rstrip("/"))
+            for d in deployed
         }
         discoverable: list[DeployedAutomation] = []
-        for src in self._discover_workspace_sources():
+        for src in scan_workspace_sources(self.workspace_repo_dir, worktree=scope):
             key = (src["automation_name"], src["relative_path"].rstrip("/"))
             if key in deployed_keys:
                 continue
@@ -459,7 +395,115 @@ class AutomationService:
                 )
             )
 
-        return list(pres.values()) + discoverable
+        return deployed + discoverable
+
+    async def refresh(self, worktree: str | None = None) -> list[DeployedAutomation]:
+        """Recompute one scope's static automation list and cache it."""
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+        entries = self._build_static_entries(worktree, bs_yaml)
+        self._cache[worktree] = entries
+        return entries
+
+    async def refresh_all(self) -> None:
+        """Refresh main + every worktree on disk; drop stale scope keys."""
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+        self._cache[None] = self._build_static_entries(None, bs_yaml)
+
+        worktrees_root = os.path.join(self.workspace_repo_dir, "worktrees")
+        live: set[str] = set()
+        if os.path.isdir(worktrees_root):
+            for entry in os.listdir(worktrees_root):
+                if entry.startswith("."):
+                    continue
+                if not os.path.isdir(os.path.join(worktrees_root, entry)):
+                    continue
+                live.add(entry)
+                self._cache[entry] = self._build_static_entries(entry, bs_yaml)
+
+        # Forget worktree scopes that have disappeared since the last refresh.
+        for stale in [k for k in self._cache.keys() if k is not None and k not in live]:
+            self._cache.pop(stale, None)
+
+    def forget_worktree(self, worktree: str) -> None:
+        self._cache.pop(worktree, None)
+
+    def _apply_docker_overlay(
+        self,
+        entries: list[DeployedAutomation],
+        containers: list[dict],
+        info: dict,
+        bs_yaml: dict,
+    ) -> None:
+        """Fill in container_id/state/status/created_at/automation_url/endpoint_name
+        on the cached static entries — in place, since each `get_automations()`
+        call constructs fresh DeployedAutomation copies from the cache snapshot.
+        """
+        gitops_domain = os.environ.get("BITSWAN_GITOPS_DOMAIN", None)
+        dep_configs = (bs_yaml or {}).get("deployments", {}) or {}
+        by_id = {a.deployment_id: a for a in entries if a.deployment_id}
+
+        for container in containers:
+            labels = container.get("Labels", {})
+            deployment_id = labels.get("gitops.deployment_id")
+            if not deployment_id or deployment_id not in by_id:
+                continue
+            a = by_id[deployment_id]
+
+            label = labels.get("gitops.intended_exposed", "false")
+            dep_conf = dep_configs.get(deployment_id, {})
+            url = generate_workspace_url(
+                self.workspace_name,
+                dep_conf.get("automation_name", deployment_id),
+                dep_conf.get("context", ""),
+                dep_conf.get("stage", "production") or "production",
+                gitops_domain,
+                True,
+            )
+            if label != "true":
+                url = None
+
+            created_str = container.get("Created")
+            created_at = None
+            if created_str:
+                try:
+                    created_at = datetime.utcfromtimestamp(created_str)
+                except (ValueError, TypeError):
+                    pass
+
+            a.container_id = container.get("Id")
+            a.endpoint_name = info.get("Name")
+            a.created_at = created_at
+            a.state = container.get("State", "unknown")
+            a.status = container.get("Status", "")
+            a.automation_url = url
+
+    async def get_automations(self) -> list[DeployedAutomation]:
+        """Return every automation across all scopes, with live Docker state.
+
+        Reads the scope-keyed static cache built by `refresh()` / `refresh_all()`;
+        Docker container state is fetched on each call and overlaid in place
+        (cheap — one Docker API call). The cache is warmed on first use if a
+        startup warmup hasn't run yet.
+        """
+        if not self._cache:
+            await self.refresh_all()
+
+        # Re-read bitswan.yaml for the overlay (URL generation needs the
+        # current deployment config). The cache itself was built from the
+        # same file, so the cost is minor.
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+
+        # Deep-copy each entry so the overlay doesn't mutate cached objects.
+        result: list[DeployedAutomation] = []
+        for entries in self._cache.values():
+            for a in entries:
+                result.append(a.model_copy() if hasattr(a, "model_copy") else a)
+
+        docker_client = get_async_docker_client()
+        info = await docker_client.info()
+        containers = await self.get_containers()
+        self._apply_docker_overlay(result, containers, info, bs_yaml)
+        return result
 
     async def materialize_merged_tree(
         self, dirs: list[str], checksum: str

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -101,7 +101,9 @@ def update_automation_toml_image(toml_path: str, new_image_value: str) -> None:
         if existing == expected_line:
             return
         # Preserve leading whitespace.
-        leading_ws_len = len(lines[image_line_idx]) - len(lines[image_line_idx].lstrip())
+        leading_ws_len = len(lines[image_line_idx]) - len(
+            lines[image_line_idx].lstrip()
+        )
         lines[image_line_idx] = lines[image_line_idx][:leading_ws_len] + expected_line
     elif deployment_section_idx >= 0:
         lines.insert(deployment_section_idx + 1, expected_line)
@@ -157,9 +159,7 @@ def scan_workspace_sources(
         source_name = os.path.basename(root)
         sanitized = sanitize_automation_name(source_name)
         rel_parts = rel_path.replace("\\", "/").split("/")
-        bp_name = (
-            sanitize_automation_name(rel_parts[0]) if len(rel_parts) >= 2 else ""
-        )
+        bp_name = sanitize_automation_name(rel_parts[0]) if len(rel_parts) >= 2 else ""
         bp_prefix = f"{bp_name}-" if bp_name else ""
 
         if worktree:
@@ -505,9 +505,7 @@ class AutomationService:
         self._apply_docker_overlay(result, containers, info, bs_yaml)
         return result
 
-    async def materialize_merged_tree(
-        self, dirs: list[str], checksum: str
-    ) -> str:
+    async def materialize_merged_tree(self, dirs: list[str], checksum: str) -> str:
         """Copy `dirs` (later-wins-on-collision) into `gitops_dir/<checksum>/`
         and commit. No-op if the target directory already exists. Returns the
         absolute output path.
@@ -538,9 +536,7 @@ class AutomationService:
             raise
 
         async with GitLockContext(timeout=10.0):
-            await call_git_command(
-                "git", "add", f"{checksum}", cwd=self.gitops_dir
-            )
+            await call_git_command("git", "add", f"{checksum}", cwd=self.gitops_dir)
             await call_git_command(
                 "git",
                 "commit",
@@ -588,7 +584,11 @@ class AutomationService:
                     entries[name] = (src, is_dir, False)
 
             for name, (src, is_dir, is_symlink) in entries.items():
-                dest = os.path.join(dest_root, rel, name) if rel else os.path.join(dest_root, name)
+                dest = (
+                    os.path.join(dest_root, rel, name)
+                    if rel
+                    else os.path.join(dest_root, name)
+                )
                 if is_symlink:
                     target = os.readlink(src)
                     if os.path.lexists(dest):
@@ -648,9 +648,7 @@ class AutomationService:
         )
 
         if not already_built and existing_status != "building":
-            logger.info(
-                f"Building automation image {full_tag} from {image_dir}"
-            )
+            logger.info(f"Building automation image {full_tag} from {image_dir}")
             await image_service.create_image(
                 tag_root,
                 build_context_path=image_dir,
@@ -715,9 +713,7 @@ class AutomationService:
         sources = scan_workspace_sources(
             self.workspace_repo_dir, worktree=scan_worktree
         )
-        source = next(
-            (s for s in sources if s["relative_path"] == relative_path), None
-        )
+        source = next((s for s in sources if s["relative_path"] == relative_path), None)
         if not source:
             ctx = f" in worktree '{worktree}'" if worktree else ""
             raise HTTPException(
@@ -741,9 +737,13 @@ class AutomationService:
             )
 
         # Resolve source dir + optional bitswan_lib for the merge.
-        source_dir = os.path.realpath(os.path.join(self.workspace_repo_dir, relative_path))
+        source_dir = os.path.realpath(
+            os.path.join(self.workspace_repo_dir, relative_path)
+        )
         ws_root_real = os.path.realpath(self.workspace_repo_dir)
-        if not (source_dir == ws_root_real or source_dir.startswith(ws_root_real + os.sep)):
+        if not (
+            source_dir == ws_root_real or source_dir.startswith(ws_root_real + os.sep)
+        ):
             raise HTTPException(status_code=400, detail="Source escapes workspace")
         bitswan_lib_dir = os.path.join(self.workspace_repo_dir, "bitswan_lib")
         dirs_to_merge = [source_dir]

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -25,6 +25,7 @@ from app.utils import (
     read_pipeline_conf,
     read_automation_config,
     remove_route_from_ingress,
+    sanitize_automation_name,
     update_git,
     call_git_command,
     call_git_command_with_output,
@@ -51,11 +52,6 @@ OAUTH2_COOKIE_REFRESH = "14m"
 def _short_hash(context: str) -> str:
     """Deterministic 4-char hash for a context string."""
     return hashlib.sha256(context.encode()).hexdigest()[:4]
-
-
-def sanitize_automation_name(name: str) -> str:
-    """Lowercase + replace anything outside [a-z0-9-] with '-', trim hyphens."""
-    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
 
 
 def update_automation_toml_image(toml_path: str, new_image_value: str) -> None:
@@ -588,6 +584,18 @@ class AutomationService:
                     if rel
                     else os.path.join(dest_root, name)
                 )
+                # If dest exists with a different type than the incoming
+                # entry, remove it so the write below succeeds. Mirrors the
+                # hash overlay's type-aware later-wins behavior.
+                if os.path.lexists(dest):
+                    dest_is_link = os.path.islink(dest)
+                    dest_is_dir = (not dest_is_link) and os.path.isdir(dest)
+                    incoming_is_real_dir = is_dir and not is_symlink
+                    if dest_is_dir != incoming_is_real_dir:
+                        if dest_is_dir:
+                            shutil.rmtree(dest)
+                        else:
+                            os.unlink(dest)
                 if is_symlink:
                     target = os.readlink(src)
                     if os.path.lexists(dest):

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -19,7 +19,6 @@ from app.utils import (
     bitswan_extract_filter,
     get_expose_to_for_stage,
     calculate_git_tree_hash,
-    calculate_merged_git_tree_hash,
     docker_compose_up,
     generate_workspace_url,
     read_bitswan_yaml,
@@ -513,7 +512,7 @@ class AutomationService:
         Mirrors `_upload_and_commit_asset`'s contract but sources files from
         the workspace bind-mount instead of an upload stream. Symlinks are
         preserved verbatim (same as the hash function), so the materialized
-        tree round-trips through `calculate_merged_git_tree_hash` to the same
+        tree round-trips through `calculate_git_tree_hash` to the same
         digest.
         """
         output_dir = os.path.join(self.gitops_dir, checksum)
@@ -558,7 +557,7 @@ class AutomationService:
     def _copy_merged_tree_sync(dirs: list[str], dest_root: str) -> None:
         """Walk `dirs` in order, writing each entry into `dest_root` with
         later-wins semantics. Mirrors the entry-map logic in
-        `calculate_merged_git_tree_hash` so the materialized tree hashes back
+        `calculate_git_tree_hash` so the materialized tree hashes back
         to the same checksum.
         """
 
@@ -636,7 +635,7 @@ class AutomationService:
         workspace = self.workspace_name or "workspace"
         tag_root = f"{workspace}-{bp_name}-{auto_name}"
 
-        image_checksum = await calculate_git_tree_hash(image_dir)
+        image_checksum = await calculate_git_tree_hash([image_dir])
         full_tag = f"internal/{tag_root}:sha{image_checksum}"
 
         image_service = ImageService()
@@ -753,7 +752,7 @@ class AutomationService:
         if stage == "live-dev":
             checksum = "live-dev"
         else:
-            checksum = await calculate_merged_git_tree_hash(dirs_to_merge)
+            checksum = await calculate_git_tree_hash(dirs_to_merge)
             await self.materialize_merged_tree(dirs_to_merge, checksum)
 
         # Build the per-automation runtime image if the source ships a
@@ -832,7 +831,7 @@ class AutomationService:
                         zip_ref.extractall(output_dir)
 
                 # Verify the checksum using git tree hash algorithm
-                calculated_hash = await calculate_git_tree_hash(output_dir)
+                calculated_hash = await calculate_git_tree_hash([output_dir])
                 if calculated_hash != checksum:
                     raise HTTPException(
                         status_code=400,
@@ -986,7 +985,7 @@ class AutomationService:
             raise HTTPException(status_code=400, detail=f"Invalid archive: {e}")
 
         # Verify the checksum using git tree hash algorithm
-        calculated_hash = await calculate_git_tree_hash(output_dir)
+        calculated_hash = await calculate_git_tree_hash([output_dir])
         if calculated_hash != checksum:
             shutil.rmtree(output_dir, ignore_errors=True)
             logger.error(

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -19,6 +19,7 @@ from app.utils import (
     bitswan_extract_filter,
     get_expose_to_for_stage,
     calculate_git_tree_hash,
+    calculate_merged_git_tree_hash,
     docker_compose_up,
     generate_workspace_url,
     read_bitswan_yaml,
@@ -32,6 +33,7 @@ from app.utils import (
     GitLockContext,
 )
 from app.async_docker import get_async_docker_client, DockerError
+from app.deploy_manager import deploy_manager
 from app.services.image_service import ImageService
 from app.services.oauth2_helpers import (
     OAUTH2_PROXY_PATH,
@@ -50,6 +52,142 @@ OAUTH2_COOKIE_REFRESH = "14m"
 def _short_hash(context: str) -> str:
     """Deterministic 4-char hash for a context string."""
     return hashlib.sha256(context.encode()).hexdigest()[:4]
+
+
+def sanitize_automation_name(name: str) -> str:
+    """Lowercase + replace anything outside [a-z0-9-] with '-', trim hyphens."""
+    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
+
+
+def update_automation_toml_image(toml_path: str, new_image_value: str) -> None:
+    """Rewrite the `image` field under `[deployment]` in `automation.toml`,
+    preserving the rest of the file's formatting. Creates the file (and the
+    section) if missing. Mirrors `updateAutomationTomlImageValue` in
+    `bitswan-editor/Extension/src/utils/automationImageBuilder.ts`.
+    """
+    if not os.path.exists(toml_path):
+        os.makedirs(os.path.dirname(toml_path), exist_ok=True)
+        with open(toml_path, "w") as f:
+            f.write(f'[deployment]\nimage = "{new_image_value}"\n')
+        return
+
+    with open(toml_path, "r") as f:
+        content = f.read()
+
+    newline = "\r\n" if "\r\n" in content else "\n"
+    lines = content.split(newline) if newline in content else content.split("\n")
+
+    section_re = re.compile(r"^\s*\[(.+?)\]\s*$")
+    image_re = re.compile(r"^\s*image\s*=\s*")
+
+    in_deployment = False
+    image_line_idx = -1
+    deployment_section_idx = -1
+    for i, raw in enumerate(lines):
+        m = section_re.match(raw)
+        if m:
+            in_deployment = m.group(1).strip().lower() == "deployment"
+            if in_deployment:
+                deployment_section_idx = i
+            continue
+        if in_deployment and image_re.match(raw):
+            image_line_idx = i
+            break
+
+    expected_line = f'image = "{new_image_value}"'
+
+    if image_line_idx >= 0:
+        existing = lines[image_line_idx].strip()
+        if existing == expected_line:
+            return
+        # Preserve leading whitespace.
+        leading_ws_len = len(lines[image_line_idx]) - len(lines[image_line_idx].lstrip())
+        lines[image_line_idx] = lines[image_line_idx][:leading_ws_len] + expected_line
+    elif deployment_section_idx >= 0:
+        lines.insert(deployment_section_idx + 1, expected_line)
+    else:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.append("[deployment]")
+        lines.append(expected_line)
+
+    with open(toml_path, "w") as f:
+        f.write(newline.join(lines))
+
+
+# Directories never considered as automation sources during workspace scans.
+_SCAN_SKIP_DIRS = {"templates", "worktrees", ".git"}
+
+
+def scan_workspace_sources(
+    workspace_root: str, worktree: str | None = None
+) -> list[dict]:
+    """Walk the filesystem for automation sources marked by `automation.toml`.
+
+    Scans the main workspace when `worktree` is None, or the named worktree's
+    subtree otherwise. Returns one dict per automation directory with enough
+    metadata for both deploy-time use and dashboard discovery.
+
+    Each entry:
+        deployment_id  — id matching the editor's existing live-dev format
+        automation_name — sanitized basename
+        display_name    — original directory name (unsanitized)
+        context         — BP name (or "wt-{worktree}-{bp}" for worktree scans)
+        stage           — always "live-dev" (caller may override)
+        relative_path   — workspace-relative path (with "worktrees/<wt>/" prefix
+                          for worktree scans)
+        source_path     — absolute filesystem path
+        worktree        — the worktree name or None
+    """
+    if worktree:
+        scan_root = os.path.join(workspace_root, "worktrees", worktree)
+    else:
+        scan_root = workspace_root
+    if not os.path.isdir(scan_root):
+        return []
+
+    results: list[dict] = []
+    seen_ids: set[str] = set()
+    for root, dirs, files in os.walk(scan_root):
+        dirs[:] = [d for d in dirs if d not in _SCAN_SKIP_DIRS]
+        if "automation.toml" not in files:
+            continue
+
+        rel_path = os.path.relpath(root, scan_root)
+        source_name = os.path.basename(root)
+        sanitized = sanitize_automation_name(source_name)
+        rel_parts = rel_path.replace("\\", "/").split("/")
+        bp_name = (
+            sanitize_automation_name(rel_parts[0]) if len(rel_parts) >= 2 else ""
+        )
+        bp_prefix = f"{bp_name}-" if bp_name else ""
+
+        if worktree:
+            bp_suffix = f"-{bp_name}" if bp_name else ""
+            context = f"wt-{worktree}{bp_suffix}"
+            deployment_id = f"{sanitized}-{context}-live-dev"
+            relative_path = f"worktrees/{worktree}/{rel_path}"
+        else:
+            context = bp_name
+            deployment_id = f"{sanitized}-{bp_prefix}live-dev"
+            relative_path = rel_path
+
+        if deployment_id in seen_ids:
+            continue
+        seen_ids.add(deployment_id)
+        results.append(
+            {
+                "deployment_id": deployment_id,
+                "automation_name": sanitized,
+                "display_name": source_name,
+                "context": context,
+                "stage": "live-dev",
+                "relative_path": relative_path,
+                "source_path": root,
+                "worktree": worktree,
+            }
+        )
+    return results
 
 
 MAX_NAME_LEN = 24
@@ -170,12 +308,32 @@ class AutomationService:
         )
         return containers
 
+    def _discover_workspace_sources(self) -> list[dict]:
+        """List every `automation.toml` directory under the workspace repo.
+
+        Combines the main workspace with each worktree under
+        `<workspace_repo>/worktrees/`. Used by `get_automations()` to surface
+        automations that exist on disk but have not been deployed yet.
+        """
+        sources = scan_workspace_sources(self.workspace_repo_dir, worktree=None)
+        worktrees_root = os.path.join(self.workspace_repo_dir, "worktrees")
+        if os.path.isdir(worktrees_root):
+            for entry in os.listdir(worktrees_root):
+                if entry.startswith("."):
+                    continue
+                if not os.path.isdir(os.path.join(worktrees_root, entry)):
+                    continue
+                sources.extend(
+                    scan_workspace_sources(self.workspace_repo_dir, worktree=entry)
+                )
+        return sources
+
     async def get_automations(self):
         """Get all automations with their container status using async Docker client."""
         bs_yaml = read_bitswan_yaml(self.gitops_dir)
 
         if not bs_yaml:
-            return []
+            bs_yaml = {"deployments": {}}
 
         pres = {
             deployment_id: DeployedAutomation(
@@ -264,7 +422,334 @@ class AutomationService:
                     replicas=pres[deployment_id].replicas,
                 )
 
-        return list(pres.values())
+        # Discoverable entries — sources that exist on disk but aren't in
+        # `bitswan.yaml`. Surfaced so the dashboard can offer a Deploy button
+        # for them. Matched by automation_name + relative_path against any
+        # already-deployed entry; matched ones are dropped (the deployed entry
+        # already covers them).
+        deployed_keys = {
+            (
+                (p.automation_name or "").lower(),
+                (p.relative_path or "").rstrip("/"),
+            )
+            for p in pres.values()
+        }
+        discoverable: list[DeployedAutomation] = []
+        for src in self._discover_workspace_sources():
+            key = (src["automation_name"], src["relative_path"].rstrip("/"))
+            if key in deployed_keys:
+                continue
+            discoverable.append(
+                DeployedAutomation(
+                    container_id=None,
+                    endpoint_name=None,
+                    created_at=None,
+                    name=src["display_name"],
+                    state=None,
+                    status=None,
+                    deployment_id=None,
+                    active=False,
+                    automation_url=None,
+                    relative_path=src["relative_path"],
+                    stage=None,
+                    automation_name=src["automation_name"],
+                    context=src["context"],
+                    version_hash=None,
+                    replicas=1,
+                )
+            )
+
+        return list(pres.values()) + discoverable
+
+    async def materialize_merged_tree(
+        self, dirs: list[str], checksum: str
+    ) -> str:
+        """Copy `dirs` (later-wins-on-collision) into `gitops_dir/<checksum>/`
+        and commit. No-op if the target directory already exists. Returns the
+        absolute output path.
+
+        Mirrors `_upload_and_commit_asset`'s contract but sources files from
+        the workspace bind-mount instead of an upload stream. Symlinks are
+        preserved verbatim (same as the hash function), so the materialized
+        tree round-trips through `calculate_merged_git_tree_hash` to the same
+        digest.
+        """
+        output_dir = os.path.join(self.gitops_dir, checksum)
+        if os.path.exists(output_dir) and os.listdir(output_dir):
+            return output_dir
+
+        tmp_dir = output_dir + ".tmp"
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)
+        os.makedirs(tmp_dir, exist_ok=True)
+
+        try:
+            self._copy_merged_tree_sync(dirs, tmp_dir)
+            if os.path.exists(output_dir):
+                shutil.rmtree(output_dir)
+            os.rename(tmp_dir, output_dir)
+        except Exception:
+            if os.path.exists(tmp_dir):
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
+
+        async with GitLockContext(timeout=10.0):
+            await call_git_command(
+                "git", "add", f"{checksum}", cwd=self.gitops_dir
+            )
+            await call_git_command(
+                "git",
+                "commit",
+                "-m",
+                f"Add asset {checksum} (workspace-mounted)",
+                cwd=self.gitops_dir,
+            )
+            # Push is best-effort — there may be no remote configured in dev.
+            try:
+                await call_git_command("git", "push", cwd=self.gitops_dir)
+            except Exception:
+                logger.warning(
+                    "git push failed after materialize_merged_tree; continuing"
+                )
+
+        return output_dir
+
+    @staticmethod
+    def _copy_merged_tree_sync(dirs: list[str], dest_root: str) -> None:
+        """Walk `dirs` in order, writing each entry into `dest_root` with
+        later-wins semantics. Mirrors the entry-map logic in
+        `calculate_merged_git_tree_hash` so the materialized tree hashes back
+        to the same checksum.
+        """
+
+        def walk(rel: str) -> None:
+            entries: dict[str, tuple[str, bool, bool]] = {}
+            for d in dirs:
+                full = os.path.join(d, rel) if rel else d
+                if not os.path.isdir(full):
+                    continue
+                for name in os.listdir(full):
+                    if name == ".git":
+                        continue
+                    src = os.path.join(full, name)
+                    is_symlink = os.path.islink(src)
+                    if is_symlink:
+                        entries[name] = (src, False, True)
+                        continue
+                    is_dir = os.path.isdir(src)
+                    if not is_dir and not os.path.isfile(src):
+                        continue
+                    if not os.access(src, os.R_OK):
+                        continue
+                    entries[name] = (src, is_dir, False)
+
+            for name, (src, is_dir, is_symlink) in entries.items():
+                dest = os.path.join(dest_root, rel, name) if rel else os.path.join(dest_root, name)
+                if is_symlink:
+                    target = os.readlink(src)
+                    if os.path.lexists(dest):
+                        os.unlink(dest)
+                    os.symlink(target, dest)
+                elif is_dir:
+                    os.makedirs(dest, exist_ok=True)
+                    walk(f"{rel}/{name}" if rel else name)
+                else:
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    shutil.copy2(src, dest, follow_symlinks=False)
+
+        walk("")
+
+    async def _ensure_automation_image(
+        self,
+        source_dir: str,
+    ) -> str | None:
+        """Build the automation's image from `<source_dir>/image/Dockerfile` and
+        write the resulting tag into `<source_dir>/automation.toml`.
+
+        Mirrors `ensureAutomationImageReady` in
+        `bitswan-editor/Extension/src/utils/automationImageBuilder.ts`:
+
+          * Image content-addressed by the git-tree hash of the `image/`
+            subdirectory.
+          * Tag template: `internal/{workspace}-{bp}-{automation}:sha{checksum}`.
+          * Skips the build if an image with the same tag is already present.
+          * Updates `automation.toml` so subsequent deploys (and the existing
+            editor flow) pick up the freshly-built tag.
+
+        Returns the resolved image tag, or `None` if the automation has no
+        `image/` directory (in which case `deploy_automation` falls back to
+        the runtime-environment default).
+        """
+        image_dir = os.path.join(source_dir, "image")
+        if not os.path.isfile(os.path.join(image_dir, "Dockerfile")):
+            return None
+
+        auto_name = sanitize_automation_name(
+            os.path.basename(source_dir.rstrip(os.sep))
+        )
+        parent = os.path.dirname(source_dir.rstrip(os.sep))
+        bp_name = sanitize_automation_name(os.path.basename(parent))
+        workspace = self.workspace_name or "workspace"
+        tag_root = f"{workspace}-{bp_name}-{auto_name}"
+
+        image_checksum = await calculate_git_tree_hash(image_dir)
+        full_tag = f"internal/{tag_root}:sha{image_checksum}"
+
+        image_service = ImageService()
+        existing_status = image_service._get_build_status(image_checksum)
+        images = await image_service.get_images()
+        already_built = any(
+            im.get("tag") == full_tag and im.get("build_status") in (None, "ready")
+            for im in images
+        )
+
+        if not already_built and existing_status != "building":
+            logger.info(
+                f"Building automation image {full_tag} from {image_dir}"
+            )
+            await image_service.create_image(
+                tag_root,
+                build_context_path=image_dir,
+                checksum=image_checksum,
+            )
+
+        if not already_built:
+            # Poll until the build finishes (or fails). The 5-minute deadline
+            # matches the editor-side helper.
+            deadline = asyncio.get_event_loop().time() + 5 * 60
+            while True:
+                status = image_service._get_build_status(image_checksum)
+                if status == "ready":
+                    break
+                if status == "failed":
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Image build failed for {full_tag}",
+                    )
+                if asyncio.get_event_loop().time() >= deadline:
+                    raise HTTPException(
+                        status_code=504,
+                        detail=f"Image build timed out for {full_tag}",
+                    )
+                await asyncio.sleep(2)
+
+        # Write the resolved tag into automation.toml so the rest of the
+        # deploy pipeline (and the editor) sees the up-to-date image.
+        update_automation_toml_image(
+            os.path.join(source_dir, "automation.toml"), full_tag
+        )
+        return full_tag
+
+    async def start_deploy_from_workspace(
+        self,
+        relative_path: str,
+        stage: str,
+        worktree: str | None = None,
+    ) -> dict:
+        """Deploy an automation directly from the bind-mounted workspace.
+
+        Replaces the editor's upload-and-deploy flow for the cases where the
+        workspace is always co-located with gitops (which it is in our
+        topology). Discovers the source via `scan_workspace_sources`, merges
+        `bitswan_lib` if present, computes a real merged-tree checksum,
+        materializes the merged tree under `<gitops_dir>/<checksum>/`, and
+        delegates to `deploy_automation`.
+
+        `stage="live-dev"` skips the materialization step and uses the literal
+        "live-dev" checksum, matching the existing `start-live-dev` endpoint.
+        """
+        if stage not in {"dev", "live-dev"}:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported stage '{stage}' (allowed: dev, live-dev)",
+            )
+
+        # Find the source via the same scan agent.py uses, so the
+        # deployment_id format matches. For dev stage we still scan from the
+        # main workspace (no worktree); for live-dev we honour `worktree`.
+        scan_worktree = worktree if stage == "live-dev" else None
+        sources = scan_workspace_sources(
+            self.workspace_repo_dir, worktree=scan_worktree
+        )
+        source = next(
+            (s for s in sources if s["relative_path"] == relative_path), None
+        )
+        if not source:
+            ctx = f" in worktree '{worktree}'" if worktree else ""
+            raise HTTPException(
+                status_code=404,
+                detail=f"No automation source at '{relative_path}'{ctx}",
+            )
+
+        # deployment_id: same template the editor uses for non-live-dev
+        # stage deploys (sanitized-{bp_prefix}{stage}). The scanner's
+        # `deployment_id` ends with `-live-dev`; rewrite the suffix for the
+        # dev stage so the IDs match what bitswan-editor produces.
+        if stage == "dev":
+            deployment_id = source["deployment_id"].removesuffix("-live-dev") + "-dev"
+        else:
+            deployment_id = source["deployment_id"]
+
+        if deploy_manager.is_deploying(deployment_id):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Deployment {deployment_id} is already in progress",
+            )
+
+        # Resolve source dir + optional bitswan_lib for the merge.
+        source_dir = os.path.realpath(os.path.join(self.workspace_repo_dir, relative_path))
+        ws_root_real = os.path.realpath(self.workspace_repo_dir)
+        if not (source_dir == ws_root_real or source_dir.startswith(ws_root_real + os.sep)):
+            raise HTTPException(status_code=400, detail="Source escapes workspace")
+        bitswan_lib_dir = os.path.join(self.workspace_repo_dir, "bitswan_lib")
+        dirs_to_merge = [source_dir]
+        if os.path.isdir(bitswan_lib_dir):
+            dirs_to_merge.append(bitswan_lib_dir)
+
+        if stage == "live-dev":
+            checksum = "live-dev"
+        else:
+            checksum = await calculate_merged_git_tree_hash(dirs_to_merge)
+            await self.materialize_merged_tree(dirs_to_merge, checksum)
+
+        # Build the per-automation runtime image if the source ships a
+        # Dockerfile under `image/`. Editor uploads do this client-side; for
+        # our workspace-mounted deploys gitops handles it itself, blocking
+        # on the build so `deploy_automation` reads the correct image tag
+        # from the (just-updated) `automation.toml`.
+        try:
+            await self._ensure_automation_image(source_dir)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Image build failed: {exc}",
+            )
+
+        task = await deploy_manager.create_task(deployment_id)
+        if task is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Deployment {deployment_id} is already in progress",
+            )
+
+        deploy_kwargs = dict(
+            deployment_id=deployment_id,
+            checksum=checksum,
+            stage=stage,
+            relative_path=source["relative_path"],
+            automation_name=source["automation_name"],
+            context=source["context"],
+        )
+
+        return {
+            "deployment_id": deployment_id,
+            "task_id": task.task_id,
+            "checksum": checksum,
+            "deploy_kwargs": deploy_kwargs,
+            "source": source,
+        }
 
     async def _upload_and_commit_asset(
         self,

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -405,7 +405,7 @@ class ImageService:
                             zip_ref.extractall(temp_dir_path)
 
                     # Verify the checksum using git tree hash algorithm
-                    calculated_hash = await calculate_git_tree_hash(temp_dir_path)
+                    calculated_hash = await calculate_git_tree_hash([temp_dir_path])
                     if calculated_hash != checksum:
                         raise HTTPException(
                             status_code=400,

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -316,8 +316,6 @@ async def create_automation_from_template(
     if template_id and group_id:
         raise ValueError("template_id and group_id are mutually exclusive")
 
-    listing = discover_templates(workspace_root)
-
     bp_full, bp_rel = _bp_destination(workspace_root, bp, worktree)
     os.makedirs(bp_full, exist_ok=True)
 

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -142,7 +142,9 @@ def _read_group(dir_path: str) -> Optional[TemplateGroupInfo]:
     )
 
 
-def _discover_in_root(root_dir: str) -> tuple[list[TemplateInfo], list[TemplateGroupInfo]]:
+def _discover_in_root(
+    root_dir: str,
+) -> tuple[list[TemplateInfo], list[TemplateGroupInfo]]:
     templates: list[TemplateInfo] = []
     groups: list[TemplateGroupInfo] = []
     if not os.path.isdir(root_dir):
@@ -172,7 +174,9 @@ def discover_templates(workspace_root: str) -> dict:
     of the same id, matching the editor's behaviour.
     """
     builtin_t, builtin_g = _discover_in_root(TEMPLATES_ROOT)
-    override_t, override_g = _discover_in_root(os.path.join(workspace_root, "templates"))
+    override_t, override_g = _discover_in_root(
+        os.path.join(workspace_root, "templates")
+    )
 
     by_id_t: dict[str, TemplateInfo] = {t.id: t for t in builtin_t}
     by_id_g: dict[str, TemplateGroupInfo] = {g.id: g for g in builtin_g}
@@ -258,7 +262,9 @@ def _ensure_automation_id(target_dir: str) -> None:
         f.write(newline.join(lines))
 
 
-def _bp_destination(workspace_root: str, bp: str, worktree: Optional[str]) -> tuple[str, str]:
+def _bp_destination(
+    workspace_root: str, bp: str, worktree: Optional[str]
+) -> tuple[str, str]:
     """Returns `(bp_full_path, bp_relative_path)`."""
     rel = os.path.join("worktrees", worktree, bp) if worktree else bp
     return os.path.join(workspace_root, rel), rel
@@ -341,7 +347,9 @@ async def create_automation_from_template(
         # of the resulting automation.
         _copy_dir_recursive(tpl.source_dir, dest, skip={"template.toml"})
         _ensure_automation_id(dest)
-        created.append({"name": sanitized, "relative_path": os.path.join(bp_rel, sanitized)})
+        created.append(
+            {"name": sanitized, "relative_path": os.path.join(bp_rel, sanitized)}
+        )
 
         message = f"Add automation {sanitized}"
     else:
@@ -376,7 +384,9 @@ async def create_automation_from_template(
     # Commit in the workspace root (or worktree). `git` finds the right worktree
     # from the cwd, so commits land on the right branch automatically.
     commit_cwd = (
-        os.path.join(workspace_root, "worktrees", worktree) if worktree else workspace_root
+        os.path.join(workspace_root, "worktrees", worktree)
+        if worktree
+        else workspace_root
     )
     try:
         await _commit(commit_cwd, message)

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -1,0 +1,406 @@
+"""
+Discover automation templates and scaffold new automations from them.
+
+Ported from the dashboard server's `services/templates.ts` so gitops owns the
+single write path into `/workspace-repo` and can broadcast `automations`
+events inline (no filesystem-watcher round-trip).
+
+The `examples/` directory the editor uses is bind-mounted at
+`/workspace/examples`; workspace-local overrides live at
+`<workspace_repo>/templates/`. Workspace overrides win on id collision.
+"""
+
+import logging
+import os
+import re
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+from app.utils import (
+    GitLockContext,
+    call_git_command,
+    call_git_command_with_output,
+)
+
+logger = logging.getLogger(__name__)
+
+# Same root the editor uses. Mounted read-only into the gitops container by
+# bitswan-automation-server's compose generation.
+TEMPLATES_ROOT = "/workspace/examples"
+
+# Editor-compatible automation directory naming.
+_AUTOMATION_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Same regex extraction strategy as the editor and the dashboard server. A real
+# TOML parser would be overkill for three fields and would lose the option of
+# preserving authoring conventions when we rewrite `automation.toml`.
+_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+_SHORT_DESC_RE = re.compile(r'\bshort_description\s*=\s*"""([\s\S]*?)"""')
+_ICON_RE = re.compile(r'\bicon\s*=\s*"""([\s\S]*?)"""')
+
+
+@dataclass
+class TemplateInfo:
+    id: str
+    name: str
+    short_description: str
+    icon_svg: str
+    source_dir: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "shortDescription": self.short_description,
+            "iconSvg": self.icon_svg,
+        }
+
+
+@dataclass
+class TemplateGroupInfo:
+    id: str
+    name: str
+    short_description: str
+    icon_svg: str
+    automations: list[str] = field(default_factory=list)
+    source_dir: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "shortDescription": self.short_description,
+            "iconSvg": self.icon_svg,
+            "automations": list(self.automations),
+        }
+
+
+def _read_metadata(path: str) -> Optional[dict]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError:
+        return None
+    m = _NAME_RE.search(content)
+    if not m:
+        return None
+    sd = _SHORT_DESC_RE.search(content)
+    ic = _ICON_RE.search(content)
+    return {
+        "name": m.group(1).strip(),
+        "short_description": (sd.group(1) if sd else "").strip(),
+        "icon_svg": (ic.group(1) if ic else "").strip(),
+    }
+
+
+def _read_template(dir_path: str) -> Optional[TemplateInfo]:
+    toml_path = os.path.join(dir_path, "template.toml")
+    if not os.path.exists(toml_path):
+        return None
+    meta = _read_metadata(toml_path)
+    if not meta:
+        return None
+    return TemplateInfo(
+        id=os.path.basename(dir_path),
+        name=meta["name"],
+        short_description=meta["short_description"],
+        icon_svg=meta["icon_svg"],
+        source_dir=dir_path,
+    )
+
+
+def _read_group(dir_path: str) -> Optional[TemplateGroupInfo]:
+    toml_path = os.path.join(dir_path, "group.toml")
+    if not os.path.exists(toml_path):
+        return None
+    meta = _read_metadata(toml_path)
+    if not meta:
+        return None
+    automations: list[str] = []
+    try:
+        for name in os.listdir(dir_path):
+            sub = os.path.join(dir_path, name)
+            if not os.path.isdir(sub):
+                continue
+            if os.path.exists(os.path.join(sub, "automation.toml")) or os.path.exists(
+                os.path.join(sub, "pipelines.conf")
+            ):
+                automations.append(name)
+    except OSError:
+        pass
+    if not automations:
+        return None
+    return TemplateGroupInfo(
+        id=os.path.basename(dir_path),
+        name=meta["name"],
+        short_description=meta["short_description"],
+        icon_svg=meta["icon_svg"],
+        automations=sorted(automations),
+        source_dir=dir_path,
+    )
+
+
+def _discover_in_root(root_dir: str) -> tuple[list[TemplateInfo], list[TemplateGroupInfo]]:
+    templates: list[TemplateInfo] = []
+    groups: list[TemplateGroupInfo] = []
+    if not os.path.isdir(root_dir):
+        return templates, groups
+    try:
+        names = os.listdir(root_dir)
+    except OSError:
+        return templates, groups
+    for name in names:
+        full = os.path.join(root_dir, name)
+        if not os.path.isdir(full):
+            continue
+        t = _read_template(full)
+        if t:
+            templates.append(t)
+            continue
+        g = _read_group(full)
+        if g:
+            groups.append(g)
+    return templates, groups
+
+
+def discover_templates(workspace_root: str) -> dict:
+    """Return the merged `{templates, groups}` listing.
+
+    Workspace overrides at `<workspace_root>/templates/` win against built-ins
+    of the same id, matching the editor's behaviour.
+    """
+    builtin_t, builtin_g = _discover_in_root(TEMPLATES_ROOT)
+    override_t, override_g = _discover_in_root(os.path.join(workspace_root, "templates"))
+
+    by_id_t: dict[str, TemplateInfo] = {t.id: t for t in builtin_t}
+    by_id_g: dict[str, TemplateGroupInfo] = {g.id: g for g in builtin_g}
+    for t in override_t:
+        by_id_t[t.id] = t
+    for g in override_g:
+        by_id_g[g.id] = g
+
+    return {
+        "templates": [
+            t.to_dict() for t in sorted(by_id_t.values(), key=lambda x: x.name.lower())
+        ],
+        "groups": [
+            g.to_dict() for g in sorted(by_id_g.values(), key=lambda x: x.name.lower())
+        ],
+    }
+
+
+def sanitize_automation_name(name: str) -> str:
+    """lowercase, non-`[a-z0-9-]` collapsed to `-`, trim leading/trailing dashes."""
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = re.sub(r"^-+|-+$", "", s)
+    return s
+
+
+def _copy_dir_recursive(src: str, dest: str, skip: Optional[set[str]] = None) -> None:
+    """Symlink-preserving recursive copy. Symlinks are re-created with their
+    original (verbatim) target, since templates ship links pointing at
+    in-container paths (e.g. `bitswan_lib` → `/workspace/bitswan_lib`)."""
+    if not os.path.isdir(src):
+        raise ValueError(f"Template source is not a directory: {src}")
+    os.makedirs(dest, exist_ok=True)
+    for name in os.listdir(src):
+        if skip and name in skip:
+            continue
+        s = os.path.join(src, name)
+        d = os.path.join(dest, name)
+        if os.path.islink(s):
+            target = os.readlink(s)
+            os.symlink(target, d)
+        elif os.path.isdir(s):
+            _copy_dir_recursive(s, d)
+        elif os.path.isfile(s):
+            shutil.copyfile(s, d)
+
+
+def _ensure_automation_id(target_dir: str) -> None:
+    """Add `[deployment] id = "<uuid>"` to `automation.toml` if missing.
+
+    Targeted string edit (not a TOML round-trip) so authoring conventions
+    (comments, blank lines) survive. Mirrors the editor + dashboard logic.
+    """
+    toml_path = os.path.join(target_dir, "automation.toml")
+    new_id = str(uuid.uuid4())
+    if not os.path.exists(toml_path):
+        with open(toml_path, "w", encoding="utf-8") as f:
+            f.write(f'[deployment]\nid = "{new_id}"\n')
+        return
+    with open(toml_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    # If `[deployment]` already has an `id`, leave alone.
+    if re.search(r"\[deployment\][\s\S]*?(^\s*id\s*=\s*)", content, re.MULTILINE):
+        return
+
+    newline = "\r\n" if "\r\n" in content else "\n"
+    lines = content.split(newline)
+    deployment_idx = -1
+    for i, raw in enumerate(lines):
+        trimmed = raw.strip()
+        if trimmed.startswith("[") and trimmed.endswith("]"):
+            if trimmed.lower() == "[deployment]":
+                deployment_idx = i
+                break
+    if deployment_idx >= 0:
+        lines.insert(deployment_idx + 1, f'id = "{new_id}"')
+    else:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.append("[deployment]")
+        lines.append(f'id = "{new_id}"')
+    with open(toml_path, "w", encoding="utf-8") as f:
+        f.write(newline.join(lines))
+
+
+def _bp_destination(workspace_root: str, bp: str, worktree: Optional[str]) -> tuple[str, str]:
+    """Returns `(bp_full_path, bp_relative_path)`."""
+    rel = os.path.join("worktrees", worktree, bp) if worktree else bp
+    return os.path.join(workspace_root, rel), rel
+
+
+async def _commit(
+    cwd: str, message: str, author_email: str = "gitops@bitswan.local"
+) -> Optional[str]:
+    """Stage everything under `cwd` and commit. Returns commit hash or None
+    if there was nothing to commit. Raises on hard failures."""
+    async with GitLockContext(timeout=15.0):
+        ok = await call_git_command("git", "add", "-A", cwd=cwd)
+        if not ok:
+            raise RuntimeError("git add -A failed")
+
+        author = f"{author_email} <{author_email}>"
+        stdout, stderr, rc = await call_git_command_with_output(
+            "git", "commit", "-m", message, "--author", author, cwd=cwd
+        )
+        if rc != 0:
+            if "nothing to commit" in stdout or "nothing to commit" in stderr:
+                return None
+            raise RuntimeError(f"git commit failed: {stderr.strip()}")
+
+    hash_stdout, _, hash_rc = await call_git_command_with_output(
+        "git", "rev-parse", "HEAD", cwd=cwd
+    )
+    return hash_stdout.strip() if hash_rc == 0 else None
+
+
+async def create_automation_from_template(
+    *,
+    workspace_root: str,
+    bp: str,
+    template_id: Optional[str] = None,
+    group_id: Optional[str] = None,
+    name: Optional[str] = None,
+    worktree: Optional[str] = None,
+) -> dict:
+    """Copy a template (or every automation in a group) into the BP directory
+    and commit. Returns `{ "created": [ { "name", "relative_path" } ] }`.
+
+    Validation of `bp`/`worktree` shape is expected to happen at the route layer.
+    """
+    if not bp:
+        raise ValueError("bp is required")
+    if not template_id and not group_id:
+        raise ValueError("template_id or group_id is required")
+    if template_id and group_id:
+        raise ValueError("template_id and group_id are mutually exclusive")
+
+    listing = discover_templates(workspace_root)
+
+    bp_full, bp_rel = _bp_destination(workspace_root, bp, worktree)
+    os.makedirs(bp_full, exist_ok=True)
+
+    created: list[dict] = []
+
+    if template_id:
+        tpl: Optional[TemplateInfo] = None
+        # Re-resolve against the in-memory discovery to fetch source_dir.
+        for t in _all_templates(workspace_root):
+            if t.id == template_id:
+                tpl = t
+                break
+        if tpl is None:
+            raise ValueError(f"Unknown template: {template_id}")
+
+        sanitized = sanitize_automation_name(name or "")
+        if not sanitized or not _AUTOMATION_NAME_RE.match(sanitized):
+            raise ValueError("Invalid automation name")
+
+        dest = os.path.join(bp_full, sanitized)
+        if os.path.exists(dest):
+            raise FileExistsError(
+                f'A folder named "{sanitized}" already exists in this business process.'
+            )
+
+        # Skip `template.toml` itself — it's metadata for the gallery, not part
+        # of the resulting automation.
+        _copy_dir_recursive(tpl.source_dir, dest, skip={"template.toml"})
+        _ensure_automation_id(dest)
+        created.append({"name": sanitized, "relative_path": os.path.join(bp_rel, sanitized)})
+
+        message = f"Add automation {sanitized}"
+    else:
+        # group_id branch
+        group: Optional[TemplateGroupInfo] = None
+        for g in _all_groups(workspace_root):
+            if g.id == group_id:
+                group = g
+                break
+        if group is None:
+            raise ValueError(f"Unknown group: {group_id}")
+
+        # Validate up front — refuse the whole operation rather than half-creating.
+        for automation in group.automations:
+            if os.path.exists(os.path.join(bp_full, automation)):
+                raise FileExistsError(
+                    f'A folder named "{automation}" already exists in this business process.'
+                )
+
+        for automation in group.automations:
+            src = os.path.join(group.source_dir, automation)
+            dest = os.path.join(bp_full, automation)
+            _copy_dir_recursive(src, dest)
+            _ensure_automation_id(dest)
+            created.append(
+                {"name": automation, "relative_path": os.path.join(bp_rel, automation)}
+            )
+
+        names = ", ".join(c["name"] for c in created)
+        message = f"Add automations: {names}"
+
+    # Commit in the workspace root (or worktree). `git` finds the right worktree
+    # from the cwd, so commits land on the right branch automatically.
+    commit_cwd = (
+        os.path.join(workspace_root, "worktrees", worktree) if worktree else workspace_root
+    )
+    try:
+        await _commit(commit_cwd, message)
+    except Exception as e:  # noqa: BLE001 — surface commit failures but don't undo the copy
+        logger.warning("template commit failed: %s", e)
+
+    return {"created": created}
+
+
+def _all_templates(workspace_root: str) -> list[TemplateInfo]:
+    """Helper to re-fetch the full TemplateInfo (incl. source_dir) — `discover_templates`
+    returns dicts trimmed for HTTP response."""
+    builtin_t, _ = _discover_in_root(TEMPLATES_ROOT)
+    override_t, _ = _discover_in_root(os.path.join(workspace_root, "templates"))
+    merged: dict[str, TemplateInfo] = {t.id: t for t in builtin_t}
+    for t in override_t:
+        merged[t.id] = t
+    return list(merged.values())
+
+
+def _all_groups(workspace_root: str) -> list[TemplateGroupInfo]:
+    _, builtin_g = _discover_in_root(TEMPLATES_ROOT)
+    _, override_g = _discover_in_root(os.path.join(workspace_root, "templates"))
+    merged: dict[str, TemplateGroupInfo] = {g.id: g for g in builtin_g}
+    for g in override_g:
+        merged[g.id] = g
+    return list(merged.values())

--- a/app/services/template_service.py
+++ b/app/services/template_service.py
@@ -22,6 +22,7 @@ from app.utils import (
     GitLockContext,
     call_git_command,
     call_git_command_with_output,
+    sanitize_automation_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -195,14 +196,6 @@ def discover_templates(workspace_root: str) -> dict:
     }
 
 
-def sanitize_automation_name(name: str) -> str:
-    """lowercase, non-`[a-z0-9-]` collapsed to `-`, trim leading/trailing dashes."""
-    s = name.lower()
-    s = re.sub(r"[^a-z0-9-]+", "-", s)
-    s = re.sub(r"^-+|-+$", "", s)
-    return s
-
-
 def _copy_dir_recursive(src: str, dest: str, skip: Optional[set[str]] = None) -> None:
     """Symlink-preserving recursive copy. Symlinks are re-created with their
     original (verbatim) target, since templates ship links pointing at
@@ -221,7 +214,7 @@ def _copy_dir_recursive(src: str, dest: str, skip: Optional[set[str]] = None) ->
         elif os.path.isdir(s):
             _copy_dir_recursive(s, d)
         elif os.path.isfile(s):
-            shutil.copyfile(s, d)
+            shutil.copy2(s, d, follow_symlinks=False)
 
 
 def _ensure_automation_id(target_dir: str) -> None:

--- a/app/utils.py
+++ b/app/utils.py
@@ -653,9 +653,7 @@ def _calculate_merged_git_tree_hash_recursive(
     entry_map: dict[str, tuple[str, bool, bool]] = {}
 
     for dir_path in dir_paths:
-        full_dir = (
-            os.path.join(dir_path, relative_path) if relative_path else dir_path
-        )
+        full_dir = os.path.join(dir_path, relative_path) if relative_path else dir_path
         if not os.path.isdir(full_dir):
             continue
         for item in os.listdir(full_dir):
@@ -665,9 +663,7 @@ def _calculate_merged_git_tree_hash_recursive(
             is_symlink = os.path.islink(item_path)
             if not is_symlink and not os.access(item_path, os.R_OK):
                 if logger:
-                    entry_rel = (
-                        f"{relative_path}/{item}" if relative_path else item
-                    )
+                    entry_rel = f"{relative_path}/{item}" if relative_path else item
                     logger.info(f"Skipping unreadable: {entry_rel}")
                 continue
             if is_symlink:
@@ -682,18 +678,14 @@ def _calculate_merged_git_tree_hash_recursive(
         key = f"{name}/" if is_dir else name
         return key.encode("utf-8")
 
-    items = sorted(
-        entry_map.items(), key=lambda kv: _git_sort_key(kv[0], kv[1][1])
-    )
+    items = sorted(entry_map.items(), key=lambda kv: _git_sort_key(kv[0], kv[1][1]))
 
     entries: list[dict] = []
     for name, (item_path, is_dir, is_symlink) in items:
         entry_rel = f"{relative_path}/{name}" if relative_path else name
         if is_symlink:
             target = os.readlink(item_path)
-            blob_hash = _calculate_git_blob_hash_from_content(
-                target.encode("utf-8")
-            )
+            blob_hash = _calculate_git_blob_hash_from_content(target.encode("utf-8"))
             entries.append({"mode": "120000", "name": name, "hash": blob_hash})
             if logger:
                 logger.info(

--- a/app/utils.py
+++ b/app/utils.py
@@ -636,6 +636,132 @@ async def calculate_git_tree_hash(dir_path: str) -> str:
     return result
 
 
+def _calculate_merged_git_tree_hash_recursive(
+    dir_paths: list[str], relative_path: str = "", logger=None
+) -> str | None:
+    """
+    Compute the git tree hash of a virtual tree formed by overlaying
+    `dir_paths` in order — later paths win on filename collisions.
+
+    Mirrors the TypeScript algorithm in
+    `bitswan-editor/Extension/src/lib.ts:557+` so checksums computed here
+    match what the editor produces when uploading a pre-merged tar.
+
+    Returns `None` for an empty merged directory (git does not track empties).
+    """
+    # name -> (source_path, is_directory, is_symlink); later dirs overwrite earlier
+    entry_map: dict[str, tuple[str, bool, bool]] = {}
+
+    for dir_path in dir_paths:
+        full_dir = (
+            os.path.join(dir_path, relative_path) if relative_path else dir_path
+        )
+        if not os.path.isdir(full_dir):
+            continue
+        for item in os.listdir(full_dir):
+            if item == ".git":
+                continue
+            item_path = os.path.join(full_dir, item)
+            is_symlink = os.path.islink(item_path)
+            if not is_symlink and not os.access(item_path, os.R_OK):
+                if logger:
+                    entry_rel = (
+                        f"{relative_path}/{item}" if relative_path else item
+                    )
+                    logger.info(f"Skipping unreadable: {entry_rel}")
+                continue
+            if is_symlink:
+                entry_map[item] = (item_path, False, True)
+                continue
+            is_dir = os.path.isdir(item_path)
+            if not is_dir and not os.path.isfile(item_path):
+                continue
+            entry_map[item] = (item_path, is_dir, False)
+
+    def _git_sort_key(name: str, is_dir: bool) -> bytes:
+        key = f"{name}/" if is_dir else name
+        return key.encode("utf-8")
+
+    items = sorted(
+        entry_map.items(), key=lambda kv: _git_sort_key(kv[0], kv[1][1])
+    )
+
+    entries: list[dict] = []
+    for name, (item_path, is_dir, is_symlink) in items:
+        entry_rel = f"{relative_path}/{name}" if relative_path else name
+        if is_symlink:
+            target = os.readlink(item_path)
+            blob_hash = _calculate_git_blob_hash_from_content(
+                target.encode("utf-8")
+            )
+            entries.append({"mode": "120000", "name": name, "hash": blob_hash})
+            if logger:
+                logger.info(
+                    f"CHECKSUM LINK: {entry_rel} -> 120000 {blob_hash} (target: {target})"
+                )
+        elif is_dir:
+            tree_hash = _calculate_merged_git_tree_hash_recursive(
+                dir_paths, entry_rel, logger
+            )
+            if tree_hash is None:
+                if logger:
+                    logger.info(f"Skipping empty directory: {entry_rel}/")
+                continue
+            entries.append({"mode": "040000", "name": name, "hash": tree_hash})
+            if logger:
+                logger.info(f"CHECKSUM DIR:  {entry_rel}/ -> {tree_hash}")
+        else:
+            blob_hash = _calculate_git_blob_hash(item_path)
+            file_mode = os.stat(item_path).st_mode
+            mode = "100755" if file_mode & 0o111 else "100644"
+            entries.append({"mode": mode, "name": name, "hash": blob_hash})
+            if logger:
+                logger.info(f"CHECKSUM FILE: {entry_rel} -> {mode} {blob_hash}")
+
+    if not entries:
+        return None
+
+    entry_bytes = bytearray()
+    for entry in entries:
+        hash_bytes = bytes.fromhex(entry["hash"])
+        entry_str = f"{entry['mode']} {entry['name']}\0"
+        entry_bytes.extend(entry_str.encode("utf-8"))
+        entry_bytes.extend(hash_bytes)
+    tree_content = bytes(entry_bytes)
+    tree_header = f"tree {len(tree_content)}\0".encode("utf-8")
+    return hashlib.sha1(tree_header + tree_content).hexdigest()
+
+
+async def calculate_merged_git_tree_hash(dir_paths: list[str]) -> str:
+    """Async wrapper over `_calculate_merged_git_tree_hash_recursive`.
+
+    Raises if every input directory is missing or empty (git does not track
+    empty trees and the caller should treat that as an error).
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.info(
+        f"=== SERVER MERGED CHECKSUM CALCULATION START for {len(dir_paths)} dirs ==="
+    )
+    for dp in dir_paths:
+        logger.info(f"  - {dp}")
+
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(
+        None,
+        lambda: _calculate_merged_git_tree_hash_recursive(dir_paths, "", logger),
+    )
+
+    if result is None:
+        raise ValueError(
+            f"Merged directories are empty (no deployable files): {dir_paths}"
+        )
+
+    logger.info(f"=== SERVER MERGED CHECKSUM CALCULATION END: {result} ===")
+    return result
+
+
 async def update_git(
     bitswan_home: str,
     bitswan_home_host: str,

--- a/app/utils.py
+++ b/app/utils.py
@@ -524,51 +524,59 @@ def _calculate_git_blob_hash(file_path: str) -> str:
 
 
 def _calculate_git_tree_hash_recursive(
-    dir_path: str, relative_path: str = "", logger=None
+    dir_paths: list[str], relative_path: str = "", logger=None
 ) -> str:
     """
     Calculate git tree hash for a directory recursively.
     Implements git's tree object format directly without spawning git processes.
     Tree format: "tree <size>\\0<entries>" where each entry is "<mode> <name>\\0<20-byte-sha1>"
-    """
-    entries = []
 
-    # Get all entries and sort them (directories first, then alphabetical)
-    items = []
-    for item in os.listdir(dir_path):
-        if item == ".git":
+    Accepts multiple `dir_paths` and overlays them in order — later paths win
+    on filename collisions. With a single path, this matches a plain
+    single-dir walk. Empty input (or all-missing dirs) yields git's empty-tree
+    SHA naturally from the tree-object encoding.
+    """
+    # name -> (source_path, is_directory, is_symlink); later dirs overwrite earlier
+    entry_map: dict[str, tuple[str, bool, bool]] = {}
+
+    for dir_path in dir_paths:
+        full_dir = os.path.join(dir_path, relative_path) if relative_path else dir_path
+        if not os.path.isdir(full_dir):
             continue
-        item_path = os.path.join(dir_path, item)
-        # lstat-style check: symlinks must be detected before any os.path.is*
-        # call that follows them. Symlinks are hashed git-style (mode 120000)
-        # so the deploy archive's checksum reflects them faithfully — the
-        # client-side calculation does the same.
-        is_symlink = os.path.islink(item_path)
-        if not is_symlink and not os.access(item_path, os.R_OK):
-            if logger:
-                entry_relative_path = (
-                    f"{relative_path}/{item}" if relative_path else item
-                )
-                logger.info(f"Skipping unreadable: {entry_relative_path}")
-            continue
-        if is_symlink:
-            items.append((item, False, True))
-            continue
-        is_dir = os.path.isdir(item_path)
-        # Skip anything that's not a regular file or directory
-        if not is_dir and not os.path.isfile(item_path):
-            continue
-        items.append((item, is_dir, False))
+        for item in os.listdir(full_dir):
+            if item == ".git":
+                continue
+            item_path = os.path.join(full_dir, item)
+            # lstat-style check: symlinks must be detected before any os.path.is*
+            # call that follows them. Symlinks are hashed git-style (mode 120000)
+            # so the deploy archive's checksum reflects them faithfully — the
+            # client-side calculation does the same.
+            is_symlink = os.path.islink(item_path)
+            if not is_symlink and not os.access(item_path, os.R_OK):
+                if logger:
+                    entry_relative_path = (
+                        f"{relative_path}/{item}" if relative_path else item
+                    )
+                    logger.info(f"Skipping unreadable: {entry_relative_path}")
+                continue
+            if is_symlink:
+                entry_map[item] = (item_path, False, True)
+                continue
+            is_dir = os.path.isdir(item_path)
+            # Skip anything that's not a regular file or directory
+            if not is_dir and not os.path.isfile(item_path):
+                continue
+            entry_map[item] = (item_path, is_dir, False)
 
     def _git_sort_key(name: str, is_dir: bool) -> bytes:
         key = f"{name}/" if is_dir else name
         return key.encode("utf-8")
 
     # Git-style ordering: symlinks sort like regular files (no trailing slash).
-    items.sort(key=lambda x: _git_sort_key(x[0], x[1]))
+    items = sorted(entry_map.items(), key=lambda kv: _git_sort_key(kv[0], kv[1][1]))
 
-    for name, is_dir, is_symlink in items:
-        item_path = os.path.join(dir_path, name)
+    entries = []
+    for name, (item_path, is_dir, is_symlink) in items:
         entry_relative_path = f"{relative_path}/{name}" if relative_path else name
 
         if is_symlink:
@@ -581,7 +589,7 @@ def _calculate_git_tree_hash_recursive(
                 )
         elif is_dir:
             tree_hash = _calculate_git_tree_hash_recursive(
-                item_path, entry_relative_path, logger
+                dir_paths, entry_relative_path, logger
             )
             entries.append({"mode": "040000", "name": name, "hash": tree_hash})
             if logger:
@@ -615,142 +623,27 @@ def _calculate_git_tree_hash_recursive(
     return result_hash
 
 
-async def calculate_git_tree_hash(dir_path: str) -> str:
+async def calculate_git_tree_hash(dir_paths: list[str]) -> str:
     """
-    Calculate git tree hash for a directory using git's tree object format.
-    This implementation directly calculates the hash without spawning git processes,
-    making it much more efficient.
+    Calculate git tree hash for one or more directories using git's tree object
+    format. Multiple directories are overlaid later-wins-on-collision (mirrors
+    the editor's pre-merged-tar checksum). Implementation calculates the hash
+    directly without spawning git processes, making it much more efficient.
     """
     import logging
 
     logger = logging.getLogger(__name__)
-    logger.info(f"=== SERVER CHECKSUM CALCULATION START for {dir_path} ===")
+    logger.info(f"=== SERVER CHECKSUM CALCULATION START for {len(dir_paths)} dirs ===")
+    for dp in dir_paths:
+        logger.info(f"  - {dp}")
 
     # Run the recursive calculation in a thread pool to keep it async
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(
-        None, lambda: _calculate_git_tree_hash_recursive(dir_path, "", logger)
+        None, lambda: _calculate_git_tree_hash_recursive(dir_paths, "", logger)
     )
 
     logger.info(f"=== SERVER CHECKSUM CALCULATION END: {result} ===")
-    return result
-
-
-def _calculate_merged_git_tree_hash_recursive(
-    dir_paths: list[str], relative_path: str = "", logger=None
-) -> str | None:
-    """
-    Compute the git tree hash of a virtual tree formed by overlaying
-    `dir_paths` in order — later paths win on filename collisions.
-
-    Mirrors the TypeScript algorithm in
-    `bitswan-editor/Extension/src/lib.ts:557+` so checksums computed here
-    match what the editor produces when uploading a pre-merged tar.
-
-    Returns `None` for an empty merged directory (git does not track empties).
-    """
-    # name -> (source_path, is_directory, is_symlink); later dirs overwrite earlier
-    entry_map: dict[str, tuple[str, bool, bool]] = {}
-
-    for dir_path in dir_paths:
-        full_dir = os.path.join(dir_path, relative_path) if relative_path else dir_path
-        if not os.path.isdir(full_dir):
-            continue
-        for item in os.listdir(full_dir):
-            if item == ".git":
-                continue
-            item_path = os.path.join(full_dir, item)
-            is_symlink = os.path.islink(item_path)
-            if not is_symlink and not os.access(item_path, os.R_OK):
-                if logger:
-                    entry_rel = f"{relative_path}/{item}" if relative_path else item
-                    logger.info(f"Skipping unreadable: {entry_rel}")
-                continue
-            if is_symlink:
-                entry_map[item] = (item_path, False, True)
-                continue
-            is_dir = os.path.isdir(item_path)
-            if not is_dir and not os.path.isfile(item_path):
-                continue
-            entry_map[item] = (item_path, is_dir, False)
-
-    def _git_sort_key(name: str, is_dir: bool) -> bytes:
-        key = f"{name}/" if is_dir else name
-        return key.encode("utf-8")
-
-    items = sorted(entry_map.items(), key=lambda kv: _git_sort_key(kv[0], kv[1][1]))
-
-    entries: list[dict] = []
-    for name, (item_path, is_dir, is_symlink) in items:
-        entry_rel = f"{relative_path}/{name}" if relative_path else name
-        if is_symlink:
-            target = os.readlink(item_path)
-            blob_hash = _calculate_git_blob_hash_from_content(target.encode("utf-8"))
-            entries.append({"mode": "120000", "name": name, "hash": blob_hash})
-            if logger:
-                logger.info(
-                    f"CHECKSUM LINK: {entry_rel} -> 120000 {blob_hash} (target: {target})"
-                )
-        elif is_dir:
-            tree_hash = _calculate_merged_git_tree_hash_recursive(
-                dir_paths, entry_rel, logger
-            )
-            if tree_hash is None:
-                if logger:
-                    logger.info(f"Skipping empty directory: {entry_rel}/")
-                continue
-            entries.append({"mode": "040000", "name": name, "hash": tree_hash})
-            if logger:
-                logger.info(f"CHECKSUM DIR:  {entry_rel}/ -> {tree_hash}")
-        else:
-            blob_hash = _calculate_git_blob_hash(item_path)
-            file_mode = os.stat(item_path).st_mode
-            mode = "100755" if file_mode & 0o111 else "100644"
-            entries.append({"mode": mode, "name": name, "hash": blob_hash})
-            if logger:
-                logger.info(f"CHECKSUM FILE: {entry_rel} -> {mode} {blob_hash}")
-
-    if not entries:
-        return None
-
-    entry_bytes = bytearray()
-    for entry in entries:
-        hash_bytes = bytes.fromhex(entry["hash"])
-        entry_str = f"{entry['mode']} {entry['name']}\0"
-        entry_bytes.extend(entry_str.encode("utf-8"))
-        entry_bytes.extend(hash_bytes)
-    tree_content = bytes(entry_bytes)
-    tree_header = f"tree {len(tree_content)}\0".encode("utf-8")
-    return hashlib.sha1(tree_header + tree_content).hexdigest()
-
-
-async def calculate_merged_git_tree_hash(dir_paths: list[str]) -> str:
-    """Async wrapper over `_calculate_merged_git_tree_hash_recursive`.
-
-    Raises if every input directory is missing or empty (git does not track
-    empty trees and the caller should treat that as an error).
-    """
-    import logging
-
-    logger = logging.getLogger(__name__)
-    logger.info(
-        f"=== SERVER MERGED CHECKSUM CALCULATION START for {len(dir_paths)} dirs ==="
-    )
-    for dp in dir_paths:
-        logger.info(f"  - {dp}")
-
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(
-        None,
-        lambda: _calculate_merged_git_tree_hash_recursive(dir_paths, "", logger),
-    )
-
-    if result is None:
-        raise ValueError(
-            f"Merged directories are empty (no deployable files): {dir_paths}"
-        )
-
-    logger.info(f"=== SERVER MERGED CHECKSUM CALCULATION END: {result} ===")
     return result
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import hashlib
 import logging
 import os
+import re
 import threading
 from typing import Any, Optional
 import shlex
@@ -193,6 +194,17 @@ def parse_automation_toml(content: str) -> AutomationConfig | None:
         services=services,
         external_testing_network=deployment.get("external-testing-network", False),
     )
+
+
+def sanitize_automation_name(name: str) -> str:
+    """Lowercase + replace each char outside [a-z0-9-] with '-', trim hyphens.
+
+    Single shared implementation: deployment-id derivation (automation_service)
+    and template scaffolding (template_service) must agree on the same output
+    for a given input, otherwise scaffolded folders won't round-trip back to
+    the same deployment id.
+    """
+    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
 
 
 def read_automation_toml(source_dir: str) -> AutomationConfig | None:


### PR DESCRIPTION
## Summary
  - Add `process_service` plus `/processes` routes for listing and creating business processes, with a cache that covers the main repo + every worktree and a scope-keyed refresh path.
  - Add `template_service` plus `/templates` routes so the dashboard can list built-in automation templates and scaffold new automations from them.
  - Add `/worktrees/{name}/status` (per-file change list combining `git status` and `git diff`) and extend `/worktrees/{name}/diff` to accept an optional `?path=` filter, with a path-validation helper to keep
  relative paths safe.
  - Broadcast `processes`, `worktrees`, and `automations` over the existing SSE feed (debounced, driven by filesystem and Docker event watchers) so the dashboard no longer needs to poll.
  - Introduce a scope-keyed automation cache in `automation_service` and overlay live Docker state on read — same data model, much cheaper rebroadcast. 
  - Refactor MQTT process publishing and `lifespan.py` startup to share the new cache layer. 
  
  