### PR TITLE
fix: worktree discovery failed on fresh workspaces since /worktree directory didn't exist yet

### DIFF
--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -490,14 +490,21 @@ async def lifespan(app: FastAPI):
         else:
             print(f"Workspace directory does not exist: {workspace_dir}")
 
-        # Watch worktree directories for file changes → SSE push
+        # Watch worktree directories for file changes → SSE push.
+        # Create the directory first so a fresh workspace (where worktrees/
+        # doesn't exist yet) still gets a watcher attached. Without this the
+        # first `POST /worktrees/create` has no listener, the cache stays
+        # empty, and `GET /worktrees/` keeps returning [] until gitops
+        # restarts. The recursive watcher on `workspace_dir` doesn't help —
+        # `WorkspaceChangeHandler` only refreshes automations/processes, not
+        # the worktrees list cache.
         worktrees_dir = os.path.join(workspace_dir, "worktrees")
-        if os.path.exists(worktrees_dir):
-            wt_handler = WorktreeChangeHandler(asyncio.get_event_loop(), worktrees_dir)
-            worktree_observer = Observer()
-            worktree_observer.schedule(wt_handler, worktrees_dir, recursive=True)
-            worktree_observer.start()
-            print(f"Started watching worktrees directory: {worktrees_dir}")
+        os.makedirs(worktrees_dir, exist_ok=True)
+        wt_handler = WorktreeChangeHandler(asyncio.get_event_loop(), worktrees_dir)
+        worktree_observer = Observer()
+        worktree_observer.schedule(wt_handler, worktrees_dir, recursive=True)
+        worktree_observer.start()
+        print(f"Started watching worktrees directory: {worktrees_dir}")
 
         # Clean up completed/failed deploy tasks every 10 minutes
         scheduler.add_job(


### PR DESCRIPTION
- Updated the logic to ensure the worktrees directory is created before attaching a file watcher, allowing for proper monitoring even in fresh workspaces.
- Improved comments to clarify the necessity of creating the directory for the watcher to function correctly, addressing potential issues with empty caches on initial worktree creation.

These changes enhance the reliability of worktree monitoring and improve the overall functionality of the application.