### PR TITLE
fix: don't append -production to hostname labels

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -196,10 +196,11 @@ def make_hostname_label(
     """
     ws = workspace_name[:MAX_NAME_LEN]
     an = automation_name[:MAX_NAME_LEN]
+    has_stage = bool(stage) and stage != "production"
     if context:
         h = _short_hash(context)
-        return f"{ws}-{an}-{h}-{stage}" if stage else f"{ws}-{an}-{h}"
-    return f"{ws}-{an}-{stage}" if stage else f"{ws}-{an}"
+        return f"{ws}-{an}-{h}-{stage}" if has_stage else f"{ws}-{an}-{h}"
+    return f"{ws}-{an}-{stage}" if has_stage else f"{ws}-{an}"
 
 
 class AutomationService:


### PR DESCRIPTION
## Summary
- `make_hostname_label` was appending `-production` to hostnames because callers normalize empty/missing stage to the literal string `"production"` before passing it in. Production deployments ended up with `workspace-automation-hash-production` instead of `workspace-automation-hash`.
- Every other suffix path in the codebase treats production as the empty-suffix default (`BITSWAN_URL_TEMPLATE`, `infra_service.service_suffix`, `worktrees.py`, `backup_service.py`), and the docs confirm `""` is the canonical production value. URLs emitted via `BITSWAN_URL_TEMPLATE` don't have `-production`, so they didn't match the ingress route — broken links like `https://demo-meeting-form-backend-2a97.nikita-sandbox.bswn.io/public/schedule`.
- Fix `make_hostname_label` to skip the suffix when `stage == "production"`, matching the rest of the codebase.

## Affected call sites (all switch to suffix-free for production)
- `automation_service.py:1592, 1792, 2476` — compose service / container names
- `automation_service.py:2772, 2847` — `BITSWAN_AUTOMATION_URL`, network alias
- `utils.py:387, 402` — ingress route hostname + upstream service name
- `agent.py:203, 324`, `automations.py:91, 162` — URLs returned to editor

## Migration note
Production deployments already running have `-production` baked into their compose service name, container name, ingress route, and network alias. They'll keep serving traffic at the old `-production` URL until they're redeployed; on next deploy they switch to the suffix-free name and the old container/route is orphaned. Coordinate a redeploy or have ops clean up stale ingress routes for `*-production` names.

## Test plan
- [ ] Deploy a fresh production automation; confirm ingress hostname is `{ws}-{auto}-{hash}.{domain}` (no `-production`)
- [ ] Confirm `BITSWAN_AUTOMATION_URL` env var matches what `BITSWAN_URL_TEMPLATE` would produce
- [ ] Deploy dev/staging/live-dev variants; confirm their suffixes still appear
- [ ] Redeploy an existing production automation; confirm new container has the new name and old `-production` container/route is cleaned up
