### PR TITLE
feat: business-process deploy/promote + auto-setup hooks

### DIFF
--- a/app/deploy_manager.py
+++ b/app/deploy_manager.py
@@ -23,6 +23,7 @@ class DeployStatus(str, Enum):
 
 
 class DeployStep(str, Enum):
+    BUILDING_IMAGES = "building_images"
     UPDATING_CONFIG = "updating_config"
     ENABLING_SERVICES = "enabling_services"
     GENERATING_COMPOSE = "generating_compose"
@@ -44,6 +45,13 @@ class DeployTask:
     build_checksum: str | None = None
     started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None
+    # Business-process deploys: one task spans multiple member deployments.
+    # These are empty/None for single-automation tasks so existing clients
+    # (which key on task_id/deployment_id/step) are unaffected.
+    bp: str | None = None
+    members: list[str] = field(default_factory=list)
+    total: int | None = None
+    current: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -58,6 +66,11 @@ class DeployTask:
             "completed_at": self.completed_at.isoformat()
             if self.completed_at
             else None,
+            # Additive BP fields — None/empty for single-automation tasks.
+            "bp": self.bp,
+            "members": self.members,
+            "total": self.total,
+            "current": self.current,
         }
 
 
@@ -81,6 +94,40 @@ class DeployManager:
             self._active_deploys[deployment_id] = task_id
             return task
 
+    async def create_bp_task(
+        self, bp: str, deployment_ids: list[str]
+    ) -> tuple["DeployTask | None", str | None]:
+        """Create a single deploy task spanning all members of a business process.
+
+        Atomically reserves every member deployment_id. Returns (task, None) on
+        success, or (None, conflicting_id) if ANY member is already deploying —
+        in which case nothing is reserved.
+        """
+        async with self._lock:
+            for did in deployment_ids:
+                if did in self._active_deploys:
+                    return None, did
+            task_id = str(uuid.uuid4())
+            task = DeployTask(
+                task_id=task_id,
+                # First member keeps the single-id contract working for old
+                # clients that match a task by deployment_id.
+                deployment_id=deployment_ids[0] if deployment_ids else bp,
+                bp=bp,
+                members=list(deployment_ids),
+                total=len(deployment_ids),
+            )
+            self._tasks[task_id] = task
+            for did in deployment_ids:
+                self._active_deploys[did] = task_id
+            return task, None
+
+    async def set_current(self, task_id: str, current: int):
+        """Update the per-member progress counter for a BP deploy task."""
+        task = self._tasks.get(task_id)
+        if task:
+            task.current = current
+
     async def update_task(
         self,
         task_id: str,
@@ -103,7 +150,12 @@ class DeployManager:
         if status in (DeployStatus.COMPLETED, DeployStatus.FAILED):
             task.completed_at = datetime.now(timezone.utc)
             async with self._lock:
-                self._active_deploys.pop(task.deployment_id, None)
+                if task.members:
+                    # BP task — release every reserved member lock.
+                    for did in task.members:
+                        self._active_deploys.pop(did, None)
+                else:
+                    self._active_deploys.pop(task.deployment_id, None)
 
     def get_task(self, task_id: str) -> DeployTask | None:
         return self._tasks.get(task_id)

--- a/app/deploy_runner.py
+++ b/app/deploy_runner.py
@@ -1,0 +1,192 @@
+"""
+Shared "deploy a set of automation sources under one task" runner.
+
+Used by the auto-deploy hooks (BP creation, worktree creation, worktree sync)
+and the manual `/automations/deploy-changed` endpoint. Lives in its own leaf
+module — `routes/automations.py` imports from `routes/agent.py`, so a helper
+shared by both (plus `routes/processes.py` and `routes/worktrees.py`) must not
+live in either route module. Imports only leaf modules; the AutomationService
+singleton is resolved lazily inside `spawn_set_deploy`.
+
+Unlike the strict `/automations/deploy-bp` endpoint (409 if ANY member is
+already deploying), `spawn_set_deploy` is best-effort: members that are
+already deploying are filtered out and reported as `skipped`, and every
+failure mode is returned in the result dict instead of raised — hooks must
+never break their parent HTTP operation.
+"""
+
+import asyncio
+import logging
+
+from app.deploy_manager import DeployStatus, DeployStep, deploy_manager
+from app.event_broadcaster import event_broadcaster
+
+logger = logging.getLogger(__name__)
+
+# Strong references to background deploy tasks — prevents GC before completion.
+_bg_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_bg(coro) -> asyncio.Task:
+    t = asyncio.create_task(coro)
+    _bg_tasks.add(t)
+    t.add_done_callback(_bg_tasks.discard)
+    return t
+
+
+async def _run_set_deploy_with_progress(
+    task_id: str,
+    label: str,
+    members: list[dict],
+    deployment_ids: list[str],
+    service,
+    stage: str,
+    worktree: str | None,
+    commit_subject: str | None,
+):
+    """Background coroutine driving `deploy_source_set` with progress
+    broadcasting. Mirrors `_run_bp_deploy_with_progress`; on terminal status
+    `deploy_manager.update_task` releases every member lock.
+    """
+
+    async def progress_callback(step: str, message: str, current: int | None = None):
+        deploy_step = DeployStep(step)
+        if current is not None:
+            await deploy_manager.set_current(task_id, current)
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            step=deploy_step,
+            message=message,
+        )
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    async def _broadcast_task():
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    try:
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            message=f"Deploying {label}...",
+        )
+        await _broadcast_task()
+
+        await service.deploy_source_set(
+            label=label,
+            members=members,
+            stage=stage,
+            worktree=worktree,
+            commit_subject=commit_subject,
+            progress_callback=progress_callback,
+        )
+
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.COMPLETED,
+            step=DeployStep.DONE,
+            message=f"{label} deployed successfully",
+        )
+        await _broadcast_task()
+    except Exception as exc:
+        logger.exception("Set deploy failed for %s (task %s)", label, task_id)
+        error_detail = str(exc)
+        if hasattr(exc, "detail"):
+            error_detail = exc.detail
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.FAILED,
+            error=error_detail,
+            message=f"{label} deployment failed",
+        )
+        await _broadcast_task()
+
+
+async def spawn_set_deploy(
+    label: str,
+    members: list[dict],
+    stage: str,
+    worktree: str | None = None,
+    commit_subject: str | None = None,
+    service=None,
+) -> dict:
+    """Reserve the deployable members under one task and spawn the background
+    set deploy. Never raises.
+
+    Members already being deployed are dropped into `skipped` (logged) rather
+    than failing the batch. Returns:
+      * `{"deploy": {"task_id", "deployment_ids"}, "skipped": [...]}` on spawn,
+      * `{"deploy": None, "reason": "no_members"|"all_in_progress"|"conflict",
+         "skipped": [...]}` when there is nothing to do,
+      * `{"deploy": None, "error": "..."}` on unexpected failure.
+    """
+    try:
+        if service is None:
+            # Lazy import keeps this module a leaf for the route modules.
+            from app.dependencies import get_automation_service
+
+            service = get_automation_service()
+
+        if not members:
+            return {"deploy": None, "reason": "no_members", "skipped": []}
+
+        pairs = [(m, service.deployment_id_for(m, stage)) for m in members]
+        skipped = [did for _, did in pairs if deploy_manager.is_deploying(did)]
+        candidates = [(m, did) for m, did in pairs if did not in skipped]
+        if skipped:
+            logger.info(
+                "Set deploy %s: skipping already-deploying members: %s",
+                label,
+                skipped,
+            )
+        if not candidates:
+            return {"deploy": None, "reason": "all_in_progress", "skipped": skipped}
+
+        members_f = [m for m, _ in candidates]
+        ids_f = [did for _, did in candidates]
+        task, conflict = await deploy_manager.create_bp_task(label, ids_f)
+        if task is None:
+            # Race: a member got reserved between the filter and the
+            # reservation. Retry once without the conflicting id.
+            logger.info(
+                "Set deploy %s: member %s reserved concurrently, retrying without it",
+                label,
+                conflict,
+            )
+            skipped = skipped + [conflict]
+            members_f = [m for m, did in candidates if did != conflict]
+            ids_f = [did for _, did in candidates if did != conflict]
+            if not ids_f:
+                return {
+                    "deploy": None,
+                    "reason": "all_in_progress",
+                    "skipped": skipped,
+                }
+            task, conflict = await deploy_manager.create_bp_task(label, ids_f)
+            if task is None:
+                skipped = skipped + [conflict]
+                return {"deploy": None, "reason": "conflict", "skipped": skipped}
+
+        _spawn_bg(
+            _run_set_deploy_with_progress(
+                task.task_id,
+                label,
+                members_f,
+                ids_f,
+                service,
+                stage,
+                worktree,
+                commit_subject,
+            )
+        )
+        return {
+            "deploy": {"task_id": task.task_id, "deployment_ids": ids_f},
+            "skipped": skipped,
+        }
+    except Exception as exc:
+        logger.exception("spawn_set_deploy failed for %s", label)
+        return {"deploy": None, "error": str(exc)}

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from app.async_docker import get_async_docker_client, DockerError
 from app.dependencies import get_automation_service
+from app.deploy_runner import spawn_set_deploy
 from app.services.automation_service import (
     AutomationService,
     make_hostname_label,
@@ -875,6 +876,35 @@ async def _complete_merge(workspace_dir: str, worktree_path: str, **_kwargs) -> 
     }
 
 
+async def _attach_sync_auto_deploy(result: dict, worktree_name: str) -> None:
+    """After a successful sync merge, deploy changed+new main automations to
+    dev in the background and attach `result["deploy"]`.
+
+    Best-effort — never raises (sync already succeeded). MUST be called AFTER
+    the sync handler's GitLockContext is released: the spawned deploy takes
+    its own git locks and the lock is non-reentrant. Zero changed members →
+    no task, no `deploy` field.
+    """
+    try:
+        service = get_automation_service()
+        members = await service.changed_dev_members()
+        if not members:
+            return
+        res = await spawn_set_deploy(
+            label=f"sync:{worktree_name}",
+            members=members,
+            stage="dev",
+            service=service,
+        )
+        if res.get("deploy"):
+            result["deploy"] = res["deploy"]
+        elif res.get("error"):
+            result["deploy"] = {"error": res["error"]}
+    except Exception as e:
+        logger.warning("Sync auto-deploy spawn failed for '%s': %s", worktree_name, e)
+        result["deploy"] = {"error": str(e)}
+
+
 @router.post("/worktrees/{worktree_name}/sync")
 async def sync_worktree(
     worktree_name: str,
@@ -949,7 +979,10 @@ async def sync_worktree(
         result = await _complete_merge(workspace_dir, worktree_path)
         if result["status"] == "error":
             raise HTTPException(status_code=500, detail=result["detail"])
-        return result
+
+    # Lock released — auto-deploy changed automations to dev (best-effort).
+    await _attach_sync_auto_deploy(result, worktree_name)
+    return result
 
 
 @router.post("/worktrees/{worktree_name}/sync-continue")
@@ -1009,7 +1042,10 @@ async def sync_continue(
         result = await _complete_merge(workspace_dir, worktree_path)
         if result["status"] == "error":
             raise HTTPException(status_code=500, detail=result["detail"])
-        return result
+
+    # Lock released — auto-deploy changed automations to dev (best-effort).
+    await _attach_sync_auto_deploy(result, worktree_name)
+    return result
 
 
 @router.post("/worktrees/{worktree_name}/sync-abort")

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -54,6 +54,12 @@ class StartDeployRequest(BaseModel):
     worktree: str | None = None
 
 
+class DeployBPRequest(BaseModel):
+    bp: str
+    stage: str  # "dev" or "live-dev"
+    worktree: str | None = None
+
+
 @router.post("/start-deploy")
 async def start_deploy(
     body: StartDeployRequest,
@@ -103,6 +109,69 @@ async def start_deploy(
             "deployment_id": prep["deployment_id"],
             "checksum": prep["checksum"],
             "url": url,
+            "status": "pending",
+        },
+    )
+
+
+@router.post("/deploy-bp")
+async def deploy_bp(
+    body: DeployBPRequest,
+    automation_service: AutomationService = Depends(get_automation_service),
+):
+    """Deploy ALL automations under one business process as a single unit.
+
+    Enumerates the BP's member automations, reserves them all atomically
+    (409 if any member is already deploying), then runs one batched deploy
+    (prep all → one bitswan.yaml write → one `docker compose up`). Progress is
+    tracked under a single BP-level task broadcast over the `deploy_progress`
+    SSE event and pollable via `/automations/deploy-status/{task_id}`.
+    """
+    if body.stage not in ("dev", "live-dev"):
+        raise HTTPException(
+            status_code=400,
+            detail="Stage must be one of: dev, live-dev",
+        )
+
+    members = automation_service.members_for_bp(
+        body.bp, worktree=body.worktree, stage=body.stage
+    )
+    if not members:
+        ctx = f" in worktree '{body.worktree}'" if body.worktree else ""
+        raise HTTPException(
+            status_code=404,
+            detail=f"No deployable automations under BP '{body.bp}'{ctx}",
+        )
+
+    deployment_ids = [
+        automation_service.deployment_id_for(m, body.stage) for m in members
+    ]
+
+    task, conflict = await deploy_manager.create_bp_task(body.bp, deployment_ids)
+    if task is None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Deployment {conflict} is already in progress",
+        )
+
+    _spawn_bg(
+        _run_bp_deploy_with_progress(
+            task.task_id,
+            body.bp,
+            deployment_ids,
+            automation_service,
+            stage=body.stage,
+            worktree=body.worktree,
+            members=members,
+        )
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "task_id": task.task_id,
+            "bp": body.bp,
+            "deployment_ids": deployment_ids,
             "status": "pending",
         },
     )
@@ -247,6 +316,77 @@ async def _run_deploy_with_progress(
             status=DeployStatus.FAILED,
             error=error_detail,
             message="Deployment failed",
+        )
+        await _broadcast_task()
+
+
+async def _run_bp_deploy_with_progress(
+    task_id: str,
+    bp: str,
+    deployment_ids: list[str],
+    automation_service: AutomationService,
+    stage: str,
+    worktree: str | None,
+    members: list[dict],
+):
+    """Background coroutine running a BP deploy with progress broadcasting.
+
+    Mirrors `_run_deploy_with_progress` but drives `deploy_business_process`.
+    On terminal status, `deploy_manager.update_task` releases every member lock.
+    """
+
+    async def progress_callback(step: str, message: str, current: int | None = None):
+        deploy_step = DeployStep(step)
+        if current is not None:
+            await deploy_manager.set_current(task_id, current)
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            step=deploy_step,
+            message=message,
+        )
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    async def _broadcast_task():
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    try:
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            message=f"Deploying business process {bp}...",
+        )
+        await _broadcast_task()
+
+        await automation_service.deploy_business_process(
+            bp=bp,
+            stage=stage,
+            worktree=worktree,
+            members=members,
+            progress_callback=progress_callback,
+        )
+
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.COMPLETED,
+            step=DeployStep.DONE,
+            message="Business process deployed successfully",
+        )
+        await _broadcast_task()
+    except Exception as exc:
+        logger.exception("BP deploy failed for %s (task %s)", bp, task_id)
+        error_detail = str(exc)
+        if hasattr(exc, "detail"):
+            error_detail = exc.detail
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.FAILED,
+            error=error_detail,
+            message="Business process deployment failed",
         )
         await _broadcast_task()
 

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from app.deploy_manager import DeployStatus, DeployStep, deploy_manager
+from app.deploy_runner import spawn_set_deploy
 from app.event_broadcaster import event_broadcaster
 from app.routes.agent import _scan_automations
 from app.services.automation_service import AutomationService, make_hostname_label
@@ -172,6 +173,52 @@ async def deploy_bp(
             "task_id": task.task_id,
             "bp": body.bp,
             "deployment_ids": deployment_ids,
+            "status": "pending",
+        },
+    )
+
+
+@router.post("/deploy-changed")
+async def deploy_changed(
+    automation_service: AutomationService = Depends(get_automation_service),
+):
+    """Deploy every main automation whose source differs from (or has no)
+    deployed dev checksum — the same changed+new set the worktree-sync hook
+    deploys automatically. Members already being deployed are skipped.
+    """
+    members = await automation_service.changed_dev_members()
+    if not members:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "noop",
+                "message": "No changed automations",
+                "deployment_ids": [],
+            },
+        )
+
+    res = await spawn_set_deploy(
+        label="deploy-changed",
+        members=members,
+        stage="dev",
+        service=automation_service,
+    )
+    if not res.get("deploy"):
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": res.get("reason") or "error",
+                "skipped": res.get("skipped", []),
+                "error": res.get("error"),
+            },
+        )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "task_id": res["deploy"]["task_id"],
+            "deployment_ids": res["deploy"]["deployment_ids"],
+            "skipped": res.get("skipped", []),
             "status": "pending",
         },
     )

--- a/app/routes/automations.py
+++ b/app/routes/automations.py
@@ -61,6 +61,11 @@ class DeployBPRequest(BaseModel):
     worktree: str | None = None
 
 
+class PromoteBPRequest(BaseModel):
+    bp: str
+    stage: str  # "staging" or "production"
+
+
 @router.post("/start-deploy")
 async def start_deploy(
     body: StartDeployRequest,
@@ -172,6 +177,65 @@ async def deploy_bp(
         content={
             "task_id": task.task_id,
             "bp": body.bp,
+            "deployment_ids": deployment_ids,
+            "status": "pending",
+        },
+    )
+
+
+@router.post("/promote-bp")
+async def promote_bp(
+    body: PromoteBPRequest,
+    automation_service: AutomationService = Depends(get_automation_service),
+):
+    """Promote ALL automations under one business process from the previous
+    stage to `stage` as a single unit (dev→staging or staging→production).
+
+    Re-deploys each member at its source stage's recorded checksum — no image
+    builds. Reserves all target deployments atomically (409 if any is already
+    deploying); progress is tracked under one BP-level task broadcast over the
+    `deploy_progress` SSE event and pollable via
+    `/automations/deploy-status/{task_id}`.
+    """
+    if body.stage not in ("staging", "production"):
+        raise HTTPException(
+            status_code=400,
+            detail="Stage must be one of: staging, production",
+        )
+
+    members = automation_service.promotable_bp_members(body.bp, body.stage)
+    if not members:
+        source_stage = "dev" if body.stage == "staging" else "staging"
+        raise HTTPException(
+            status_code=404,
+            detail=(f"No {source_stage} deployments to promote under BP '{body.bp}'"),
+        )
+
+    deployment_ids = [m["deployment_id"] for m in members]
+
+    task, conflict = await deploy_manager.create_bp_task(body.bp, deployment_ids)
+    if task is None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Deployment {conflict} is already in progress",
+        )
+
+    _spawn_bg(
+        _run_bp_promote_with_progress(
+            task.task_id,
+            body.bp,
+            automation_service,
+            stage=body.stage,
+            members=members,
+        )
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "task_id": task.task_id,
+            "bp": body.bp,
+            "stage": body.stage,
             "deployment_ids": deployment_ids,
             "status": "pending",
         },
@@ -434,6 +498,74 @@ async def _run_bp_deploy_with_progress(
             status=DeployStatus.FAILED,
             error=error_detail,
             message="Business process deployment failed",
+        )
+        await _broadcast_task()
+
+
+async def _run_bp_promote_with_progress(
+    task_id: str,
+    bp: str,
+    automation_service: AutomationService,
+    stage: str,
+    members: list[dict],
+):
+    """Background coroutine running a BP promotion with progress broadcasting.
+
+    Mirrors `_run_bp_deploy_with_progress` but drives `promote_business_process`.
+    On terminal status, `deploy_manager.update_task` releases every member lock.
+    """
+
+    async def progress_callback(step: str, message: str, current: int | None = None):
+        deploy_step = DeployStep(step)
+        if current is not None:
+            await deploy_manager.set_current(task_id, current)
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            step=deploy_step,
+            message=message,
+        )
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    async def _broadcast_task():
+        task = deploy_manager.get_task(task_id)
+        if task:
+            await event_broadcaster.broadcast("deploy_progress", task.to_dict())
+
+    try:
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.IN_PROGRESS,
+            message=f"Promoting business process {bp} to {stage}...",
+        )
+        await _broadcast_task()
+
+        await automation_service.promote_business_process(
+            bp=bp,
+            target_stage=stage,
+            members=members,
+            progress_callback=progress_callback,
+        )
+
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.COMPLETED,
+            step=DeployStep.DONE,
+            message=f"Business process promoted to {stage} successfully",
+        )
+        await _broadcast_task()
+    except Exception as exc:
+        logger.exception("BP promote failed for %s (task %s)", bp, task_id)
+        error_detail = str(exc)
+        if hasattr(exc, "detail"):
+            error_detail = exc.detail
+        await deploy_manager.update_task(
+            task_id,
+            status=DeployStatus.FAILED,
+            error=error_detail,
+            message="Business process promotion failed",
         )
         await _broadcast_task()
 

--- a/app/routes/processes.py
+++ b/app/routes/processes.py
@@ -7,13 +7,21 @@ Same data is broadcast over `/events/stream` as a `processes` event for
 push-style consumers (the workspace dashboard).
 """
 
+import logging
+import os
 import re
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from app.dependencies import get_automation_service
+from app.deploy_runner import spawn_set_deploy
 from app.event_broadcaster import event_broadcaster
 from app.mqtt_processes import process_service
+from app.services import template_service
+from app.services.automation_service import AutomationService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/processes", tags=["processes"])
 
@@ -41,14 +49,23 @@ async def get_processes() -> list[dict]:
 
 
 @router.post("/")
-async def create_process(body: CreateProcessRequest) -> dict:
-    """Create a new business-process directory.
+async def create_process(
+    body: CreateProcessRequest,
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> dict:
+    """Create a new business-process directory with auto-setup.
 
     Scaffolds `process.toml` + `README.md` under either `<workspace_repo>/<name>/`
     or `<workspace_repo>/worktrees/<worktree>/<name>/`. The new BP surfaces
     over the SSE feed within the same response (this route refreshes the
     cache + broadcasts inline instead of waiting for the filesystem watcher
     to debounce).
+
+    Auto-setup (best-effort): the default template group
+    (`BITSWAN_DEFAULT_TEMPLATE_GROUP`, default `BitSwanInternalAppGolang`) is
+    scaffolded into the new BP, and its deploy is kicked off in the background
+    — `dev` stage for a main BP, `live-dev` for a worktree BP. Failures never
+    fail the BP creation; they surface in the `setup_error` response field.
     """
     name = (body.name or "").strip()
     if not _PROCESS_NAME_RE.match(name):
@@ -82,4 +99,59 @@ async def create_process(body: CreateProcessRequest) -> dict:
     except Exception:
         pass
 
+    # Auto-setup: scaffold the default template group into the new BP and
+    # kick off its deploy in the background. Best-effort — the BP was already
+    # created; any failure is logged + reported via `setup_error`.
+    automations_created: list[str] = []
+    deploy_task_id: str | None = None
+    setup_error: str | None = None
+    try:
+        group_id = os.environ.get(
+            "BITSWAN_DEFAULT_TEMPLATE_GROUP", "BitSwanInternalAppGolang"
+        )
+        workspace_root = os.environ.get("BITSWAN_WORKSPACE_REPO_DIR", "/workspace-repo")
+        created = await template_service.create_automation_from_template(
+            workspace_root=workspace_root,
+            bp=name,
+            group_id=group_id,
+            worktree=body.worktree,
+        )
+        automations_created = [c["name"] for c in created.get("created", [])]
+
+        # Inline cache refresh + broadcast (mirrors routes/templates.py) so
+        # the new automation cards appear without waiting for the FS watcher.
+        try:
+            await automation_service.refresh(body.worktree)
+            automations = await automation_service.get_automations()
+            data = [
+                a.model_dump(mode="json") if hasattr(a, "model_dump") else a
+                for a in automations
+            ]
+            await event_broadcaster.broadcast("automations", data)
+        except Exception:
+            logger.exception("Failed to broadcast automations after BP scaffold")
+
+        stage = "live-dev" if body.worktree else "dev"
+        members = automation_service.members_for_bp(
+            name, worktree=body.worktree, stage=stage
+        )
+        res = await spawn_set_deploy(
+            label=name,
+            members=members,
+            stage=stage,
+            worktree=body.worktree,
+            service=automation_service,
+        )
+        if res.get("deploy"):
+            deploy_task_id = res["deploy"]["task_id"]
+        elif res.get("error"):
+            setup_error = res["error"]
+    except Exception as e:
+        logger.exception("BP auto-setup failed for %s", name)
+        setup_error = str(e)
+
+    entry["automations_created"] = automations_created
+    entry["deploy_task_id"] = deploy_task_id
+    if setup_error:
+        entry["setup_error"] = setup_error
     return entry

--- a/app/routes/worktrees.py
+++ b/app/routes/worktrees.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.async_docker import get_async_docker_client, DockerError
+from app.deploy_runner import spawn_set_deploy
+from app.services.automation_service import scan_workspace_sources
 from app.utils import (
     call_git_command,
     call_git_command_with_output,
@@ -376,6 +378,30 @@ async def create_worktree(body: CreateWorktreeRequest):
     result = {"name": body.branch_name, "path": worktree_path}
     if cloned_db:
         result["postgres_db"] = cloned_db
+
+    # Auto-start live-dev for every automation in the new worktree (a fresh
+    # worktree carries all of main's BPs). Best-effort — the worktree was
+    # already created; failures are logged + reported via `deploy_error`.
+    try:
+        members = scan_workspace_sources(
+            _get_workspace_dir(), worktree=body.branch_name
+        )
+        res = await spawn_set_deploy(
+            label=f"wt:{body.branch_name}",
+            members=members,
+            stage="live-dev",
+            worktree=body.branch_name,
+        )
+        if res.get("deploy"):
+            result["deploy_task_id"] = res["deploy"]["task_id"]
+        elif res.get("error"):
+            result["deploy_error"] = res["error"]
+    except Exception as e:
+        logger.warning(
+            "Worktree auto-deploy spawn failed for '%s': %s", body.branch_name, e
+        )
+        result["deploy_error"] = str(e)
+
     return result
 
 

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1071,21 +1071,25 @@ class AutomationService:
 
         return deployment_result
 
-    async def deploy_business_process(
+    async def deploy_source_set(
         self,
-        bp: str,
+        label: str,
+        members: list[dict],
         stage: str,
         worktree: str | None = None,
-        members: list[dict] | None = None,
         deployed_by: str | None = None,
+        commit_subject: str | None = None,
         progress_callback: Callable[..., Any] | None = None,
     ) -> dict:
-        """Deploy every automation under one business process as a single unit.
+        """Deploy an arbitrary set of scanned automation sources as one unit.
 
-        Preps ALL members first (build images + checksum + materialize), so a
-        failure in any member aborts before bitswan.yaml is touched or any
-        container is changed. Only once all preps succeed do we write the
-        config once and run a single compose-up over the member services.
+        `members` is a non-empty list of scanner dicts (the
+        `scan_workspace_sources` shape). Preps ALL members first (build images
+        + checksum + materialize), so a failure in any member aborts before
+        bitswan.yaml is touched or any container is changed. Only once all
+        preps succeed do we write the config once and run a single compose-up
+        over the member services. `label` is cosmetic (logs/commit context);
+        the caller owns deploy-task creation and member locking.
         """
 
         async def _report(step: str, message: str, current: int | None = None):
@@ -1097,13 +1101,10 @@ class AutomationService:
                 status_code=400,
                 detail=f"Unsupported stage '{stage}' (allowed: dev, live-dev)",
             )
-
-        if members is None:
-            members = self.members_for_bp(bp, worktree, stage)
         if not members:
             raise HTTPException(
                 status_code=404,
-                detail=f"No deployable automations under BP '{bp}'",
+                detail=f"No deployable automations for '{label}'",
             )
 
         # Prep every member up-front (fail-fast — touches no containers).
@@ -1124,7 +1125,7 @@ class AutomationService:
         await self.write_deployment_entries(
             prepped,
             deployed_by=deployed_by,
-            commit_subject=f"deploy business process {bp}",
+            commit_subject=commit_subject or f"deploy {label}",
             report=_report,
         )
 
@@ -1134,11 +1135,92 @@ class AutomationService:
         )
 
         return {
-            "message": "Deployed business process successfully",
-            "bp": bp,
+            "message": "Deployed successfully",
+            "label": label,
             "deployment_ids": deployment_ids,
             "result": result,
         }
+
+    async def deploy_business_process(
+        self,
+        bp: str,
+        stage: str,
+        worktree: str | None = None,
+        members: list[dict] | None = None,
+        deployed_by: str | None = None,
+        progress_callback: Callable[..., Any] | None = None,
+    ) -> dict:
+        """Deploy every automation under one business process as a single unit.
+
+        Thin wrapper over `deploy_source_set` that enumerates the BP's members
+        and preserves the BP-specific 404 message and return shape.
+        """
+        if stage not in {"dev", "live-dev"}:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported stage '{stage}' (allowed: dev, live-dev)",
+            )
+
+        if members is None:
+            members = self.members_for_bp(bp, worktree, stage)
+        if not members:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No deployable automations under BP '{bp}'",
+            )
+
+        out = await self.deploy_source_set(
+            label=bp,
+            members=members,
+            stage=stage,
+            worktree=worktree,
+            deployed_by=deployed_by,
+            commit_subject=f"deploy business process {bp}",
+            progress_callback=progress_callback,
+        )
+
+        return {
+            "message": "Deployed business process successfully",
+            "bp": bp,
+            "deployment_ids": out["deployment_ids"],
+            "result": out["result"],
+        }
+
+    async def changed_dev_members(self) -> list[dict]:
+        """Return main-scope scanner dicts whose source differs from (or has
+        no) deployed dev checksum.
+
+        Includes NEW automations (no dev entry in bitswan.yaml) and CHANGED
+        ones (merged-tree hash != stored checksum). Unchanged entries are
+        skipped regardless of their `active` flag — only *changed* sources get
+        (re)deployed, so an explicitly stopped dev automation isn't resurrected
+        by an unrelated sync. Deleted sources (dev entry remains but the
+        source dir is gone) are intentionally NOT auto-undeployed; they simply
+        don't appear in the scan.
+
+        Cheap: one bitswan.yaml read + one workspace scan + one tree hash per
+        source. No image builds, no materialize, no docker, no git lock —
+        for an unchanged source the fresh hash equals the stored checksum
+        because prep's image-tag rewrite is idempotent and persisted in the
+        workspace source.
+        """
+        sources = scan_workspace_sources(self.workspace_repo_dir, worktree=None)
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+        deployments = bs_yaml.get("deployments", {}) or {}
+        bitswan_lib = os.path.join(self.workspace_repo_dir, "bitswan_lib")
+        lib_dirs = [bitswan_lib] if os.path.isdir(bitswan_lib) else []
+
+        changed: list[dict] = []
+        for src in sources:
+            dep_id = self.deployment_id_for(src, "dev")
+            entry = deployments.get(dep_id)
+            if entry is None:
+                changed.append(src)  # new — never dev-deployed
+                continue
+            current = await calculate_git_tree_hash([src["source_path"]] + lib_dirs)
+            if (entry or {}).get("checksum") != current:
+                changed.append(src)
+        return changed
 
     async def get_asset_diff(
         self, from_checksum: str, to_checksum: str, word_diff: bool = False

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -689,23 +689,39 @@ class AutomationService:
         )
         return full_tag
 
-    async def start_deploy_from_workspace(
+    @staticmethod
+    def deployment_id_for(source: dict, stage: str) -> str:
+        """Resolve the deployment_id for a scanned source at a given stage.
+
+        The scanner's `deployment_id` always ends with `-live-dev`; for the
+        `dev` stage rewrite the suffix so the id matches what bitswan-editor
+        produces (sanitized-{bp_prefix}{stage}).
+        """
+        if stage == "dev":
+            return source["deployment_id"].removesuffix("-live-dev") + "-dev"
+        return source["deployment_id"]
+
+    async def prep_deploy_source(
         self,
         relative_path: str,
         stage: str,
         worktree: str | None = None,
     ) -> dict:
-        """Deploy an automation directly from the bind-mounted workspace.
+        """Build + materialize one automation source, ready for deployment.
 
-        Replaces the editor's upload-and-deploy flow for the cases where the
-        workspace is always co-located with gitops (which it is in our
-        topology). Discovers the source via `scan_workspace_sources`, merges
-        `bitswan_lib` if present, computes a real merged-tree checksum,
-        materializes the merged tree under `<gitops_dir>/<checksum>/`, and
-        delegates to `deploy_automation`.
+        Pure prep — NO deploy task, NO bitswan.yaml write, NO compose-up:
+          * discover the source via `scan_workspace_sources` (so the
+            deployment_id format matches the editor's),
+          * build the per-automation runtime image if it ships an
+            `image/Dockerfile` (`_ensure_automation_image`),
+          * compute the merged-tree checksum (with `bitswan_lib`) and
+            materialize `<gitops_dir>/<checksum>/` (skipped for live-dev).
 
-        `stage="live-dev"` skips the materialization step and uses the literal
-        "live-dev" checksum, matching the existing `start-live-dev` endpoint.
+        Returns: {deployment_id, checksum, stage, relative_path,
+                  automation_name, context, source}.
+        Raises HTTPException on bad stage / missing source / image-build or
+        materialize failure. Used by both `start_deploy_from_workspace` (single)
+        and `deploy_business_process` (BP).
         """
         if stage not in {"dev", "live-dev"}:
             raise HTTPException(
@@ -713,9 +729,8 @@ class AutomationService:
                 detail=f"Unsupported stage '{stage}' (allowed: dev, live-dev)",
             )
 
-        # Find the source via the same scan agent.py uses, so the
-        # deployment_id format matches. For dev stage we still scan from the
-        # main workspace (no worktree); for live-dev we honour `worktree`.
+        # For dev stage we scan from the main workspace (no worktree); for
+        # live-dev we honour `worktree`.
         scan_worktree = worktree if stage == "live-dev" else None
         sources = scan_workspace_sources(
             self.workspace_repo_dir, worktree=scan_worktree
@@ -728,20 +743,7 @@ class AutomationService:
                 detail=f"No automation source at '{relative_path}'{ctx}",
             )
 
-        # deployment_id: same template the editor uses for non-live-dev
-        # stage deploys (sanitized-{bp_prefix}{stage}). The scanner's
-        # `deployment_id` ends with `-live-dev`; rewrite the suffix for the
-        # dev stage so the IDs match what bitswan-editor produces.
-        if stage == "dev":
-            deployment_id = source["deployment_id"].removesuffix("-live-dev") + "-dev"
-        else:
-            deployment_id = source["deployment_id"]
-
-        if deploy_manager.is_deploying(deployment_id):
-            raise HTTPException(
-                status_code=409,
-                detail=f"Deployment {deployment_id} is already in progress",
-            )
+        deployment_id = self.deployment_id_for(source, stage)
 
         # Resolve source dir + optional bitswan_lib for the merge.
         source_dir = os.path.realpath(
@@ -758,16 +760,12 @@ class AutomationService:
             dirs_to_merge.append(bitswan_lib_dir)
 
         # Build the per-automation runtime image if the source ships a
-        # Dockerfile under `image/`. Editor uploads do this client-side; for
-        # our workspace-mounted deploys gitops handles it itself, blocking
-        # on the build so `deploy_automation` reads the correct image tag
-        # from the (just-updated) `automation.toml`.
-        #
-        # This MUST run before the checksum/materialize step below: it writes
-        # the resolved image tag into the source `automation.toml`, and the
-        # dev-stage deploy reads the automation config from the materialized
-        # `<checksum>/` tree. Building afterwards would materialize a stale
-        # config and silently fall back to the default runtime image.
+        # Dockerfile under `image/`. This MUST run before the
+        # checksum/materialize step: it writes the resolved image tag into the
+        # source `automation.toml`, and the dev-stage deploy reads the
+        # automation config from the materialized `<checksum>/` tree. Building
+        # afterwards would materialize a stale config and silently fall back to
+        # the default runtime image.
         try:
             await self._ensure_automation_image(source_dir)
         except HTTPException:
@@ -784,6 +782,35 @@ class AutomationService:
             checksum = await calculate_git_tree_hash(dirs_to_merge)
             await self.materialize_merged_tree(dirs_to_merge, checksum)
 
+        return {
+            "deployment_id": deployment_id,
+            "checksum": checksum,
+            "stage": stage,
+            "relative_path": source["relative_path"],
+            "automation_name": source["automation_name"],
+            "context": source["context"],
+            "source": source,
+        }
+
+    async def start_deploy_from_workspace(
+        self,
+        relative_path: str,
+        stage: str,
+        worktree: str | None = None,
+    ) -> dict:
+        """Deploy a single automation directly from the bind-mounted workspace.
+
+        Thin wrapper over `prep_deploy_source` that additionally reserves the
+        deploy task. Discovers the source, merges `bitswan_lib`, materializes
+        the merged tree under `<gitops_dir>/<checksum>/`, and returns the
+        kwargs the deploy pipeline (`deploy_automation`) consumes.
+
+        `stage="live-dev"` skips materialization and uses the literal
+        "live-dev" checksum, matching the existing `start-live-dev` endpoint.
+        """
+        prep = await self.prep_deploy_source(relative_path, stage, worktree)
+        deployment_id = prep["deployment_id"]
+
         task = await deploy_manager.create_task(deployment_id)
         if task is None:
             raise HTTPException(
@@ -793,19 +820,324 @@ class AutomationService:
 
         deploy_kwargs = dict(
             deployment_id=deployment_id,
-            checksum=checksum,
+            checksum=prep["checksum"],
             stage=stage,
-            relative_path=source["relative_path"],
-            automation_name=source["automation_name"],
-            context=source["context"],
+            relative_path=prep["relative_path"],
+            automation_name=prep["automation_name"],
+            context=prep["context"],
         )
 
         return {
             "deployment_id": deployment_id,
             "task_id": task.task_id,
-            "checksum": checksum,
+            "checksum": prep["checksum"],
             "deploy_kwargs": deploy_kwargs,
-            "source": source,
+            "source": prep["source"],
+        }
+
+    def members_for_bp(
+        self, bp: str, worktree: str | None = None, stage: str = "dev"
+    ) -> list[dict]:
+        """Scan for every automation source under one business process.
+
+        BP membership = automations whose first path segment (after stripping
+        any `worktrees/<wt>/` prefix) matches `bp`. Comparison is done through
+        `sanitize_automation_name` on both sides so a raw directory name and
+        its sanitized form both match. Returns the scanner dicts (same shape
+        as `scan_workspace_sources`).
+        """
+        scan_worktree = worktree if stage == "live-dev" else None
+        sources = scan_workspace_sources(
+            self.workspace_repo_dir, worktree=scan_worktree
+        )
+        bp_key = sanitize_automation_name(bp)
+        out: list[dict] = []
+        for s in sources:
+            parts = (s.get("relative_path") or "").replace("\\", "/").split("/")
+            if len(parts) >= 2 and parts[0] == "worktrees":
+                parts = parts[2:]  # drop "worktrees/<wt>"
+            if parts and sanitize_automation_name(parts[0]) == bp_key:
+                out.append(s)
+        return out
+
+    async def write_deployment_entries(
+        self,
+        members: list[dict],
+        deployed_by: str | None = None,
+        commit_subject: str | None = None,
+        report: Callable[..., Any] | None = None,
+    ) -> dict:
+        """Upsert several deployment entries into bitswan.yaml in ONE write +
+        ONE git commit, then auto-enable their declared infra services.
+
+        Each member dict carries: deployment_id, checksum, stage,
+        relative_path, automation_name, context (+ optional services/replicas).
+        Mirrors the per-field mapping `deploy_automation` does, but batched.
+        Returns the re-read bs_yaml.
+        """
+
+        async def _report(step: str, message: str):
+            if report is not None:
+                await report(step, message)
+
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+        deployments = bs_yaml.setdefault("deployments", {})
+
+        for m in members:
+            deployment_id = m["deployment_id"]
+
+            # Clean up old-format worktree entries for the same automation
+            # (same logic as deploy_automation's per-deployment cleanup).
+            if (
+                "-wt-" in deployment_id
+                and m.get("stage") == "live-dev"
+                and m.get("relative_path")
+            ):
+                stale = [
+                    k
+                    for k, v in deployments.items()
+                    if k != deployment_id
+                    and "-wt-" in k
+                    and k.endswith("-live-dev")
+                    and (v or {}).get("relative_path") == m["relative_path"]
+                ]
+                for k in stale:
+                    del deployments[k]
+
+            dep = deployments.setdefault(deployment_id, {})
+            if m.get("checksum") is not None:
+                dep["checksum"] = m["checksum"]
+            if m.get("stage") is not None:
+                # Map production to empty string (canonical persisted form).
+                dep["stage"] = "" if m["stage"] == "production" else m["stage"]
+            if m.get("automation_name") is not None:
+                dep["automation_name"] = m["automation_name"]
+            if m.get("context") is not None:
+                dep["context"] = m["context"]
+            if m.get("relative_path") is not None:
+                dep["relative_path"] = m["relative_path"]
+            if m.get("services") is not None:
+                dep["services"] = m["services"]
+            if m.get("replicas") is not None:
+                dep["replicas"] = m["replicas"]
+            if "active" not in dep:
+                dep["active"] = True
+
+        # Remove stale live-dev entries that lack relative_path.
+        stale_live_devs = [
+            k
+            for k, v in deployments.items()
+            if (v or {}).get("stage") == "live-dev"
+            and not (v or {}).get("relative_path")
+        ]
+        for k in stale_live_devs:
+            logger.warning("Removing stale live-dev entry: %s", k)
+            del deployments[k]
+
+        bitswan_yaml_path = os.path.join(self.gitops_dir, "bitswan.yaml")
+        with open(bitswan_yaml_path, "w") as f:
+            yaml.dump(bs_yaml, f)
+
+        await update_git(
+            self.gitops_dir,
+            self.gitops_dir_host,
+            members[0]["deployment_id"] if members else "all",
+            "deploy",
+            deployed_by=deployed_by,
+            message=commit_subject,
+        )
+
+        bs_yaml = read_bitswan_yaml(self.gitops_dir)
+
+        # Auto-enable the union of declared services, grouped by stage.
+        by_stage: dict[str, dict] = {}
+        for m in members:
+            dep_conf = bs_yaml.get("deployments", {}).get(m["deployment_id"], {}) or {}
+            deploy_services = m.get("services") or dep_conf.get("services")
+            deploy_stage = m.get("stage") or dep_conf.get("stage") or "production"
+            if deploy_stage == "":
+                deploy_stage = "production"
+            if not deploy_services:
+                auto_conf = self.resolve_automation_config(dep_conf)
+                if auto_conf.services:
+                    deploy_services = {
+                        svc_name: {"enabled": svc_dep.enabled}
+                        for svc_name, svc_dep in auto_conf.services.items()
+                    }
+            if deploy_services:
+                by_stage.setdefault(deploy_stage, {}).update(deploy_services)
+
+        if by_stage:
+            await _report("enabling_services", "Enabling declared services...")
+            for svc_stage, services in by_stage.items():
+                await self.enable_services(services, svc_stage)
+
+        return bs_yaml
+
+    async def apply_compose_for_deployments(
+        self,
+        deployment_ids: list[str],
+        deployed_by: str | None = None,
+        report: Callable[..., Any] | None = None,
+    ) -> dict:
+        """Regenerate the full compose once and bring up the given member
+        services (+ their infra) in a single `docker compose up`, then run the
+        post-deploy hooks for each member and record image tags.
+        """
+
+        async def _report(step: str, message: str):
+            if report is not None:
+                await report(step, message)
+
+        os.environ["COMPOSE_PROJECT_NAME"] = self.workspace_name
+        bs_yaml = read_bitswan_yaml(self.gitops_dir)
+
+        await _report(
+            "generating_compose", "Generating docker-compose configuration..."
+        )
+        dc_yaml, infra_service_names = self.generate_docker_compose(bs_yaml)
+        self._save_docker_compose(dc_yaml)
+        dc_config = yaml.safe_load(dc_yaml)
+        present = set(dc_config.get("services", {}).keys())
+
+        # Compute each member's compose service name (same as deploy_automation).
+        svc_name_by_id: dict[str, str] = {}
+        for dep_id in deployment_ids:
+            dep_conf = bs_yaml.get("deployments", {}).get(dep_id, {}) or {}
+            svc_name_by_id[dep_id] = make_hostname_label(
+                self.workspace_name,
+                dep_conf.get("automation_name", dep_id),
+                dep_conf.get("context", ""),
+                dep_conf.get("stage", "production") or "production",
+            )
+
+        # Only bring up services that actually made it into the compose file
+        # (a live-dev member with no resolvable image is skipped at generation).
+        member_services = [
+            svc_name_by_id[d] for d in deployment_ids if svc_name_by_id[d] in present
+        ]
+
+        await _report("docker_compose_up", "Starting containers...")
+        deployment_result = await docker_compose_up(
+            self.gitops_dir,
+            dc_yaml,
+            container_name=None,
+            extra_services=member_services + infra_service_names,
+        )
+        await self._post_deploy_infra_services(bs_yaml)
+
+        for result in deployment_result.values():
+            if result["return_code"] != 0:
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        f"Error deploying services: \ndocker-compose:\n {dc_yaml}\n\n"
+                        f"stdout:\n {result['stdout']}\nstderr:\n{result['stderr']}\n"
+                    ),
+                )
+
+        await _report("installing_certs", "Installing certificates...")
+        for dep_id in deployment_ids:
+            await self.install_certificates_in_container(dep_id)
+        await _report("starting_oauth2_proxy", "Starting OAuth2 proxy...")
+        for dep_id in deployment_ids:
+            await self.start_oauth2_proxy_in_container(dep_id)
+        await self.start_oauth2_proxy_in_infra_services(infra_service_names)
+
+        # Record resolved image tags for each member in one final commit.
+        await _report("storing_tags", "Recording image tags...")
+        bs_yaml = read_bitswan_yaml(self.gitops_dir)
+        changed = False
+        for dep_id in deployment_ids:
+            svc_name = svc_name_by_id[dep_id]
+            if svc_name not in present:
+                continue
+            deployed_image = dc_config["services"][svc_name].get("image")
+            image_tag = await self.get_tag(deployed_image)
+            if image_tag and dep_id in bs_yaml.get("deployments", {}):
+                bs_yaml["deployments"][dep_id]["tag_checksum"] = image_tag
+                changed = True
+        if changed:
+            bitswan_yaml_path = os.path.join(self.gitops_dir, "bitswan.yaml")
+            with open(bitswan_yaml_path, "w") as f:
+                yaml.dump(bs_yaml, f)
+            await update_git(
+                self.gitops_dir,
+                self.gitops_dir_host,
+                deployment_ids[0] if deployment_ids else "all",
+                "deploy",
+                deployed_by=deployed_by,
+            )
+
+        return deployment_result
+
+    async def deploy_business_process(
+        self,
+        bp: str,
+        stage: str,
+        worktree: str | None = None,
+        members: list[dict] | None = None,
+        deployed_by: str | None = None,
+        progress_callback: Callable[..., Any] | None = None,
+    ) -> dict:
+        """Deploy every automation under one business process as a single unit.
+
+        Preps ALL members first (build images + checksum + materialize), so a
+        failure in any member aborts before bitswan.yaml is touched or any
+        container is changed. Only once all preps succeed do we write the
+        config once and run a single compose-up over the member services.
+        """
+
+        async def _report(step: str, message: str, current: int | None = None):
+            if progress_callback is not None:
+                await progress_callback(step, message, current)
+
+        if stage not in {"dev", "live-dev"}:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported stage '{stage}' (allowed: dev, live-dev)",
+            )
+
+        if members is None:
+            members = self.members_for_bp(bp, worktree, stage)
+        if not members:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No deployable automations under BP '{bp}'",
+            )
+
+        # Prep every member up-front (fail-fast — touches no containers).
+        total = len(members)
+        prepped: list[dict] = []
+        for i, src in enumerate(members, start=1):
+            await _report(
+                "building_images",
+                f"Preparing {i}/{total}: {src.get('display_name', src['relative_path'])}",
+                current=i - 1,
+            )
+            prep = await self.prep_deploy_source(src["relative_path"], stage, worktree)
+            prepped.append(prep)
+
+        await _report(
+            "updating_config", "Updating deployment configuration...", current=total
+        )
+        await self.write_deployment_entries(
+            prepped,
+            deployed_by=deployed_by,
+            commit_subject=f"deploy business process {bp}",
+            report=_report,
+        )
+
+        deployment_ids = [p["deployment_id"] for p in prepped]
+        result = await self.apply_compose_for_deployments(
+            deployment_ids, deployed_by=deployed_by, report=_report
+        )
+
+        return {
+            "message": "Deployed business process successfully",
+            "bp": bp,
+            "deployment_ids": deployment_ids,
+            "result": result,
         }
 
     async def get_asset_diff(

--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -1186,6 +1186,139 @@ class AutomationService:
             "result": out["result"],
         }
 
+    def promotable_bp_members(self, bp: str, target_stage: str) -> list[dict]:
+        """Enumerate one BP's deployments at the previous stage, shaped as
+        member dicts for `write_deployment_entries` targeting `target_stage`.
+
+        Promotion re-deploys the source stage's recorded checksum — no scan,
+        no image build, no materialize (the asset tree already lives under
+        `<gitops_dir>/<checksum>/`). Target deployment ids follow the same
+        convention as the dashboard/editor per-automation promote flow:
+        `{automation}-{bp}-staging` for staging and `{automation}-{bp}`
+        (no suffix) for production.
+        """
+        if target_stage not in {"staging", "production"}:
+            raise HTTPException(
+                status_code=400,
+                detail="Stage must be one of: staging, production",
+            )
+        source_stage = "dev" if target_stage == "staging" else "staging"
+        bs_yaml = read_bitswan_yaml(self.gitops_dir) or {"deployments": {}}
+        deployments = bs_yaml.get("deployments", {}) or {}
+        bp_key = sanitize_automation_name(bp)
+
+        members: list[dict] = []
+        for dep_id, conf in deployments.items():
+            conf = conf or {}
+            stage = conf.get("stage", "production") or "production"
+            if stage != source_stage:
+                continue
+            rel = (conf.get("relative_path") or "").replace("\\", "/")
+            parts = [p for p in rel.split("/") if p]
+            if parts and parts[0] == "worktrees":
+                continue  # worktree live-dev trees never source promotions
+            in_bp = bool(parts) and sanitize_automation_name(parts[0]) == bp_key
+            if not in_bp:
+                ctx = conf.get("context") or ""
+                in_bp = bool(ctx) and sanitize_automation_name(ctx) == bp_key
+            if not in_bp:
+                continue
+            checksum = conf.get("checksum")
+            if not checksum or checksum == "live-dev":
+                continue
+
+            automation_name = conf.get("automation_name")
+            context = conf.get("context")
+            if automation_name:
+                ctx = context or ""
+                if target_stage == "production":
+                    target_id = (
+                        f"{automation_name}-{ctx}"
+                        if ctx
+                        else f"{automation_name}-production"
+                    )
+                else:
+                    target_id = (
+                        f"{automation_name}-{ctx}-staging"
+                        if ctx
+                        else f"{automation_name}-staging"
+                    )
+            else:
+                # Legacy entry without structured name fields — derive from
+                # the source deployment id's stage suffix.
+                base = dep_id.removesuffix(f"-{source_stage}")
+                target_id = (
+                    base if target_stage == "production" else f"{base}-{target_stage}"
+                )
+
+            members.append(
+                {
+                    "deployment_id": target_id,
+                    "checksum": checksum,
+                    "stage": target_stage,
+                    "relative_path": conf.get("relative_path"),
+                    "automation_name": automation_name,
+                    "context": context,
+                    "display_name": automation_name or dep_id,
+                }
+            )
+        return members
+
+    async def promote_business_process(
+        self,
+        bp: str,
+        target_stage: str,
+        members: list[dict] | None = None,
+        deployed_by: str | None = None,
+        progress_callback: Callable[..., Any] | None = None,
+    ) -> dict:
+        """Promote every automation of one BP from the previous stage to
+        `target_stage` as a single unit: ONE bitswan.yaml write + ONE
+        compose-up over the target services.
+
+        No prep step — promotion re-deploys the source stage's recorded
+        checksums verbatim, so the deployed bits are exactly what was running
+        at the source stage even if the workspace source has since changed.
+        Existing target entries are updated in place (their replicas etc.
+        are preserved by the partial upsert).
+        """
+
+        async def _report(step: str, message: str, current: int | None = None):
+            if progress_callback is not None:
+                await progress_callback(step, message, current)
+
+        if members is None:
+            members = self.promotable_bp_members(bp, target_stage)
+        source_stage = "dev" if target_stage == "staging" else "staging"
+        if not members:
+            raise HTTPException(
+                status_code=404,
+                detail=(f"No {source_stage} deployments to promote under BP '{bp}'"),
+            )
+
+        await _report(
+            "updating_config", "Updating deployment configuration...", current=0
+        )
+        await self.write_deployment_entries(
+            members,
+            deployed_by=deployed_by,
+            commit_subject=f"promote business process {bp} to {target_stage}",
+            report=_report,
+        )
+
+        deployment_ids = [m["deployment_id"] for m in members]
+        result = await self.apply_compose_for_deployments(
+            deployment_ids, deployed_by=deployed_by, report=_report
+        )
+
+        return {
+            "message": "Promoted business process successfully",
+            "bp": bp,
+            "stage": target_stage,
+            "deployment_ids": deployment_ids,
+            "result": result,
+        }
+
     async def changed_dev_members(self) -> list[dict]:
         """Return main-scope scanner dicts whose source differs from (or has
         no) deployed dev checksum.

--- a/app/utils.py
+++ b/app/utils.py
@@ -665,6 +665,7 @@ async def update_git(
     deployment_id: str,
     action: str,
     deployed_by: str | None = None,
+    message: str | None = None,
 ):
     """
     Update git repository with changes to bitswan.yaml.
@@ -753,7 +754,7 @@ async def update_git(
             "--author",
             author,
             "-m",
-            f"{action} deployment {deployment_id}",
+            message or f"{action} deployment {deployment_id}",
             cwd=bitswan_dir,
         )
 


### PR DESCRIPTION
## Summary

  Adds **business-process-level deployment** to gitops: deploy, promote, and
  auto-deploy *every automation under a BP* as a single, atomically-tracked unit
  instead of one container at a time. Also wires three **auto-setup hooks** so
  common workflows (creating a BP, creating a worktree, syncing a worktree) deploy
  the right things automatically.

  All container orchestration reuses the existing compose machinery — this is an
  orchestration layer on top, not a rewrite of the deploy engine.

  ## What's included

  ### BP deploy/promote engine
  - `deploy_manager.py` — a BP-level `DeployTask` that spans many member
    deployments, with **atomic all-or-nothing member locking** (`create_bp_task`,
    releases every member on terminal status) and a per-member progress counter.
    New `building_images` step. All additions are backward-compatible (single
    deploys and existing SSE/`deploy-status` consumers are unaffected).
  - `automation_service.py` — factored the batched deploy into reusable seams:
    - `prep_deploy_source` — build image + checksum + materialize one source.
    - `deploy_source_set` / `deploy_business_process` — prep all members
      (fail-fast) → **one** `bitswan.yaml` write → **one** `docker compose up`.
    - `promotable_bp_members` / `promote_business_process` — promote a BP from the
      previous stage by re-deploying each member's *recorded* source checksum
      (no rebuild), target ids matching the existing per-automation promote scheme.
    - `changed_dev_members` — cheap hash-vs-stored-checksum diff used by the sync
      hook and the manual endpoint (includes new + changed; skips unchanged).
    - `members_for_bp`, `deployment_id_for`, `write_deployment_entries`,
      `apply_compose_for_deployments`.
  - `deploy_runner.py` (new leaf module) — `spawn_set_deploy`: filters
    already-deploying members, reserves the rest atomically (retry-once on race),
    spawns a tracked background deploy, and **never raises** (best-effort hooks).
    Lives in its own module to avoid the `automations.py → agent.py` import cycle.

  ### New endpoints (all under the existing `verify_token` auth)
  - `POST /automations/deploy-bp` `{bp, stage: dev|live-dev, worktree?}` — deploy a
    whole BP; 409 if any member is already deploying.
  - `POST /automations/promote-bp` `{bp, stage: staging|production}` — union promote.
  - `POST /automations/deploy-changed` — deploy every main automation whose source
    differs from its deployed dev checksum (the sync-hook set, on demand).
  - Progress for all of the above flows over the existing `deploy_progress` SSE
    event and `GET /automations/deploy-status/{task_id}`.

  ### Auto-setup hooks (best-effort — never fail the parent request)
  - **BP creation** (`POST /processes/`): scaffolds the default template group
    (`BITSWAN_DEFAULT_TEMPLATE_GROUP`, default `BitSwanInternalAppGolang`) into the
    new BP, broadcasts the fresh `automations` snapshot, and kicks a background
    deploy — `dev` for a main BP, `live-dev` for a worktree BP. Response gains
    `automations_created`, `deploy_task_id`, `setup_error?`.
  - **Worktree creation** (`POST /worktrees/create`): starts live-dev for every
    automation in the new worktree (one combined task). Response gains
    `deploy_task_id?` / `deploy_error?`.
  - **Worktree sync** (`agent.py` `sync_worktree` / `sync_continue`): after the
    merge fast-forwards main, auto-deploys the **changed + new** automations to
    `dev`. The deploy is spawned **after the git lock is released** (the lock is a
    process-wide non-reentrant `threading.Lock`); the sync response gains a
    `deploy` field the coding-agent CLI relays.

  ### Misc
  - `utils.py` — optional `message` arg on `update_git` for clean BP commit subjects.
  
  ## Notes / decisions
  - "Promote to staging" promotes every automation that has a dev deployment
    (union semantics = "make the next stage match this one").
  - Sync auto-deploy includes never-deployed automations (first dev deploy on sync)
    and skips unchanged ones; doc-only syncs are a no-op.
  - bitswan.yaml schema unchanged — BP membership is derived from `relative_path`.